### PR TITLE
fix: remove initial grid value

### DIFF
--- a/examples/remix/public/tokenami.css
+++ b/examples/remix/public/tokenami.css
@@ -56,21 +56,21 @@
 }
 
 [style*="---"] {
-  --_tk-i_height: var(---height, 0);
-  --_tk-i_min-height: var(---min-height, 0);
-  --_tk-i_margin-left: var(---margin-left, var(---ml, var(---mx, var(---m, 0))));
-  --_tk-i_margin-right: var(---margin-right, var(---mr, var(---mx, var(---m, 0))));
-  --_tk-i_margin-top: var(---margin-top, var(---mt, var(---my, var(---m, 0))));
-  --_tk-i_margin-bottom: var(---margin-bottom, var(---mb, var(---my, var(---m, 0))));
-  --_tk-i_padding-left: var(---padding-left, var(---pl, var(---px, var(---p, 0))));
-  --_tk-i_padding-right: var(---padding-right, var(---pr, var(---px, var(---p, 0))));
-  --_tk-i_padding-top: var(---padding-top, var(---pt, var(---py, var(---p, 0))));
-  --_tk-i_padding-bottom: var(---padding-bottom, var(---pb, var(---py, var(---p, 0))));
+  --_tk-i_height: var(---height, );
+  --_tk-i_min-height: var(---min-height, );
+  --_tk-i_margin-left: var(---margin-left, var(---ml, var(---mx, var(---m, ))));
+  --_tk-i_margin-right: var(---margin-right, var(---mr, var(---mx, var(---m, ))));
+  --_tk-i_margin-top: var(---margin-top, var(---mt, var(---my, var(---m, ))));
+  --_tk-i_margin-bottom: var(---margin-bottom, var(---mb, var(---my, var(---m, ))));
+  --_tk-i_padding-left: var(---padding-left, var(---pl, var(---px, var(---p, ))));
+  --_tk-i_padding-right: var(---padding-right, var(---pr, var(---px, var(---p, ))));
+  --_tk-i_padding-top: var(---padding-top, var(---pt, var(---py, var(---p, ))));
+  --_tk-i_padding-bottom: var(---padding-bottom, var(---pb, var(---py, var(---p, ))));
   --_tk-i_background-size: var(---background-size, );
   --_tk-i_background-image: var(---background-image, );
   --_tk-i_background-color: var(---background-color, var(---bg-color, ));
-  --_tk-i_background-position-x: var(---background-position-x, 0);
-  --_tk-i_background-position-y: var(---background-position-y, 0);
+  --_tk-i_background-position-x: var(---background-position-x, );
+  --_tk-i_background-position-y: var(---background-position-y, );
   --_tk-i_display: var(---display, );
   --_tk-i_flex-direction: var(---flex-direction, );
   --_tk-i_align-items: var(---align-items, );
@@ -80,7 +80,7 @@
   --_tk-i_overflow: var(---overflow, );
   --_tk-i_font-family: var(---font-family, );
   --_tk-i_line-height: var(---line-height, );
-  --_tk-i_width: var(---width, 0);
+  --_tk-i_width: var(---width, );
   --_tk-i_object-fit: var(---object-fit, );
   --_tk-i_font-size: var(---font-size, );
   --_tk-i_font-weight: var(---font-weight, );

--- a/packages/dev/src/sheet.ts
+++ b/packages/dev/src/sheet.ts
@@ -184,12 +184,11 @@ function uniqueSelector(cssProperty: string) {
  * -----------------------------------------------------------------------------------------------*/
 
 function getInitialTokenValueVars(cssProperty: Tokenami.CSSProperty, config: Tokenami.Config) {
-  const initial = config.properties?.[cssProperty]?.includes('grid') ? '0' : '';
   const aliased = (config.aliases as any)?.[cssProperty] as string[] | undefined;
   const aliases = aliased || [cssProperty];
   return aliases.reduceRight(
     (fallback, alias) => `var(${Tokenami.tokenProperty(alias)}, ${fallback})`,
-    initial
+    ''
   );
 }
 


### PR DESCRIPTION
when deselecting a grid token in dev tools, we don't want it to fallback to `0` e.g. `0` width. this change ensures it falls back to the browser defaults for the specific property.