### PR TITLE
fix: enforce custom selectors for chaining

### DIFF
--- a/examples/remix/.tokenami/tokenami.config.cjs
+++ b/examples/remix/.tokenami/tokenami.config.cjs
@@ -41,6 +41,10 @@ module.exports = createConfig({
       '50%': { transform: 'rotate(3deg)' },
     },
   },
+  selectors: {
+    ...defaultConfig.selectors,
+    'focus-hover': '&:focus:hover',
+  },
   aliases: {
     'bg-color': ['background-color'],
     m: ['mt', 'mr', 'mb', 'ml', 'mx', 'my', 'margin'],

--- a/examples/remix/app/routes/_index.tsx
+++ b/examples/remix/app/routes/_index.tsx
@@ -76,6 +76,7 @@ export default function Index() {
           '--hover_color': 'var(---,white)',
           '--transition': 'var(---,all 150ms)',
           '--hover_animation': 'var(--anim-wiggle)',
+          '--focus-hover_background-color': 'var(--color-sky-500)',
         }}
       >
         Button

--- a/examples/remix/public/tokenami.css
+++ b/examples/remix/public/tokenami.css
@@ -79,6 +79,10 @@
   background-color: var(--hover_background-color, var(--background-color));
 }
 
+[style*="--focus-hover_background-color:"]:focus:hover {
+  background-color: var(--focus-hover_background-color, var(--background-color));
+}
+
 [style*="--background-image:"] {
   background-image: var(--background-image);
 }

--- a/packages/config/src/utils.ts
+++ b/packages/config/src/utils.ts
@@ -106,8 +106,8 @@ function getSpecifictyOrderForCSSProperty(cssProperty: Supports.CSSProperty) {
 
 function getTokenPropertyParts(tokenProperty: Tokenami.TokenProperty) {
   const name = Tokenami.getTokenPropertyName(tokenProperty);
-  const [alias, ...variants] = name.split('_').reverse() as [string] & string[];
-  return { name, alias, variants };
+  const [alias, ...variants] = name.split('_').reverse() as [string, ...string[]];
+  return { name, alias, variants: variants.reverse() };
 }
 
 /* -------------------------------------------------------------------------------------------------

--- a/packages/dev/src/sheet.ts
+++ b/packages/dev/src/sheet.ts
@@ -49,8 +49,11 @@ function generate(
 
       function getVariantStyles(value: string) {
         const baseStyle = getStyles(value);
-        return variants.reduceRight((styles, variant) => {
-          const template = config.responsive?.[variant] || config.selectors?.[variant];
+        const responsive = variants.flatMap((variant) => [config.responsive?.[variant]]);
+        const selectors = variants.flatMap((variant) => [config.selectors?.[variant]]);
+        // we only allow 1 of each to enforce custom selectors for chained variants.
+        if (responsive.length > 1 || selectors.length > 1) return {};
+        return [responsive[0], selectors[0]].reduce((styles, template) => {
           return template ? { [template]: styles } : styles;
         }, baseStyle);
       }


### PR DESCRIPTION
Closes https://github.com/tokenami/tokenami/issues/79

chained selectors must be declared in the `selectors` config for now. i might rethink this later but it means theme can restrict the types of selectors people can use for greater control over specificity, which can make codebases harder to reason about.

with this change the following **will not** work (note the underscore between `focus` and `hover`):

```jsx
<div style={{ '--md_focus_hover_color': 'red' }} />
```

instead the theme must declare a `focus-hover` selector:

```js
{
  selectors: {
    ...defaultConfig.selectors,
    'focus-hover': '&:focus:hover',
  },
}
```

and use as follows:

```jsx
<div style={{ '--md_focus-hover_color': 'red' }} />
```

to clarify, this means the tokenami property format can only be one of the following in order to generate the necessary CSS:

- `{responsive}_{selector}_{property}` 
- `{responsive}_{property}` 
- `{selector}_{property}` 