### PR TITLE
feat: add `VariantProps` type

### DIFF
--- a/examples/remix/app/css.ts
+++ b/examples/remix/app/css.ts
@@ -1,6 +1,7 @@
-import { createCss } from '@tokenami/css';
+import { type VariantProps, createCss } from '@tokenami/css';
 import config from '../.tokenami/tokenami.config.cjs';
 
 const css = createCss(config);
 
+export type { VariantProps };
 export { css };

--- a/packages/css/src/index.ts
+++ b/packages/css/src/index.ts
@@ -1,1 +1,4 @@
 export { createCss, css } from './css';
+export type VariantProps<T extends () => {}> = Parameters<T>[0] extends undefined | null
+  ? {}
+  : NonNullable<Parameters<T>[0]>;

--- a/packages/dev/src/declarations.ts
+++ b/packages/dev/src/declarations.ts
@@ -473,4 +473,4 @@ type TokenamiAliasStyles = {
 
 interface TokenamiStyles extends TokenamiBaseStyles, UnionToIntersection<TokenamiAliasStyles> {}
 
-export type { TokenamiConfig, TokenamiFinalConfig, TokenamiStyles };
+export type { TokenamiConfig, TokenamiFinalConfig, TokenamiStyles, ResponsiveKey };


### PR DESCRIPTION
exports a `VariantProps` type from `@tokenami/css` for easier typing of custom components, e.g:

```tsx
import { type VariantProps, css } from '@tokenami/css';

const button = css(
  { '---padding': 4 },
  {
    size: {
      small: { '--padding': 2 },
      large: { '--padding': 6 },
    },
  },
);

type NativeButtonProps = React.ComponentPropsWithoutRef<'button'>;
interface ButtonProps extends NativeButtonProps, VariantProps<typeof button> {}

const Button: React.FC<ButtonProps> = (props) => {
  const { size, style, ...buttonProps } = props;
  return <button {...buttonProps} style={button({ size }, style)} />;
}
```