### PR TITLE
feat: add browserslist env support

### DIFF
--- a/.changeset/lovely-ads-sniff.md
+++ b/.changeset/lovely-ads-sniff.md
@@ -1,0 +1,8 @@
+---
+'@tokenami/dev': patch
+'@tokenami/config': patch
+'@tokenami/css': patch
+'@tokenami/typescript-plugin': patch
+---
+
+Allow prod/dev configurations for browserslist

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ npx tokenami init
 
 ### Configure TypeScript
 
-Ensure that your editor is configured to use the project's version of TypeScript. You can find instructions for various editors in their documentation, such as for VSCode [here](https://code.visualstudio.com/docs/typescript/typescript-compiling#_using-the-workspace-version-of-typescript). Then add Tokenami to your tsconfig `include` and `plugins`:
+Ensure that your editor is configured to use the project's version of TypeScript. You can find instructions for various editors in their documentation, such as for VSCode [here](https://code.visualstudio.com/docs/typescript/typescript-compiling#_using-the-workspace-version-of-typescript). Then add Tokenami to your `include` and `plugins` in your `tsconfig.json` or `jsconfig.json`:
 
 ```json
 {

--- a/examples/remix/package.json
+++ b/examples/remix/package.json
@@ -39,7 +39,12 @@
     "/build",
     "/public/build"
   ],
-  "browserslist": [
-    "Chrome >= 14"
-  ]
+  "browserslist": {
+    "production": [
+      "Chrome >= 90"
+    ],
+    "development": [
+      "Chrome >= 14"
+    ]
+  }
 }

--- a/packages/dev/src/cli.ts
+++ b/packages/dev/src/cli.ts
@@ -43,9 +43,7 @@ const run = () => {
       const configPath = Tokenami.getConfigPath(cwd, flags.config);
       const projectPkgJson = require(pathe.join(cwd, 'package.json'));
       const config = Tokenami.getConfigAtPath(configPath);
-      const targets = projectPkgJson.browserslist
-        ? browserslistToTargets(browserslist(projectPkgJson.browserslist))
-        : undefined;
+      const targets = browserslistToTargets(getBrowsersList(projectPkgJson.browserslist));
 
       config.include = flags.files || config.include;
       if (!config.include.length) log.error('Provide a glob pattern to include files');
@@ -86,6 +84,17 @@ const run = () => {
   cli.version(pkgJson.version);
   cli.parse();
 };
+
+/* -------------------------------------------------------------------------------------------------
+ * getBrowsersList
+ * -----------------------------------------------------------------------------------------------*/
+
+function getBrowsersList(config: any) {
+  const environment = process.env.NODE_ENV || 'development';
+  const isValid = Array.isArray(config) || typeof config === 'string';
+  const narrowedConfig = isValid ? config : typeof config === 'object' ? config[environment] : [];
+  return browserslist(narrowedConfig);
+}
 
 /* -------------------------------------------------------------------------------------------------
  * generateStyles

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9271,7 +9271,7 @@ packages:
   file:packages/typescript-plugin:
     resolution: {directory: packages/typescript-plugin, type: directory}
     name: '@tokenami/typescript-plugin'
-    version: 1.0.0
+    version: 0.0.1
     dependencies:
       '@tokenami/config': link:packages/config
       require-from-string: 2.0.2


### PR DESCRIPTION
i noticed when i was testing tokenami in a `create-react-app` that a new cra app has a browserslist config that looks something like this:

```json
{
  "browserslist": {
    "production": ["/* ... */"],
    "development": ["/* ... */"],
  }
}
```

since this isn't a valid browserslist targets shape, tokenami was falling over. 

this pr checks the shape and selects the relevent config based on `NODE_ENV` if it is an object shape.
