### PR TITLE
fix: generate alias css w/o restarting

### DIFF
--- a/.changeset/lemon-beans-reply.md
+++ b/.changeset/lemon-beans-reply.md
@@ -1,0 +1,8 @@
+---
+'@tokenami/dev': patch
+'@tokenami/config': patch
+'@tokenami/css': patch
+'@tokenami/ts-plugin': patch
+---
+
+Generate alias CSS without restarting watch script

--- a/packages/dev/src/cli.ts
+++ b/packages/dev/src/cli.ts
@@ -71,8 +71,8 @@ const run = () => {
       const startTime = startTimer();
       const configPath = Tokenami.getConfigPath(cwd, flags.config);
       const projectPkgJson = require(pathe.join(cwd, 'package.json'));
-      const config = Tokenami.getConfigAtPath(configPath);
       const targets = browserslistToTargets(getBrowsersList(projectPkgJson.browserslist));
+      let config = Tokenami.getConfigAtPath(configPath);
 
       config.include = flags.files || config.include;
       if (!config.include.length) log.error('Provide a glob pattern to include files');
@@ -93,9 +93,9 @@ const run = () => {
         tokenWatcher.on('all', (_, file) => regenerateStylesheet(file, config));
 
         configWatcher.on('all', async (_, file) => {
-          const reloadedConfig = Tokenami.getReloadedConfigAtPath(configPath);
-          reloadedConfig.include = flags.files || reloadedConfig.include;
-          regenerateStylesheet(file, reloadedConfig);
+          config = Tokenami.getReloadedConfigAtPath(configPath);
+          config.include = flags.files || config.include;
+          regenerateStylesheet(file, config);
         });
 
         process.once('SIGINT', async () => {


### PR DESCRIPTION
if the watch script was running and a new alias was added to config, using that alias would not generate the necessary css without restarting the watch script. this fixes that.