### PR TITLE
feat: remove css properties from token suggestions

### DIFF
--- a/.changeset/fast-bottles-smash.md
+++ b/.changeset/fast-bottles-smash.md
@@ -1,0 +1,8 @@
+---
+'@tokenami/ts-plugin': patch
+'@tokenami/config': patch
+'@tokenami/css': patch
+'@tokenami/dev': patch
+---
+
+Remove css properties from tokenami intellisense


### PR DESCRIPTION
improves the DX by removing CSS properties from the intellisense when in a string literal property. this allows user to type `'b'` and get `'--background-color'` suggestions up top instead of `backgroundColor`.

also moves cursor to end of string (after closing quotation mark) when selecting an item from intellisense, for continuity.

| BEFORE | AFTER |
| - | - |
| <video src="https://github.com/tokenami/tokenami/assets/175330/d8dee3ac-67fa-4a94-9ef7-20b29cf53999" controls="controls" muted="muted" class="d-block rounded-bottom-2 border-top width-fit" style="max-height:640px; min-height: 200px"></video> | <video src="https://github.com/tokenami/tokenami/assets/175330/6eaf79e0-252e-4a42-af4e-f29014fff6ae" controls="controls" muted="muted" class="d-block rounded-bottom-2 border-top width-fit" style="max-height:640px; min-height: 200px"><video> |







