### PR TITLE
fix: add token delimiter to fix intellisense

### DIFF
--- a/.changeset/lucky-shoes-smile.md
+++ b/.changeset/lucky-shoes-smile.md
@@ -1,0 +1,8 @@
+---
+'@tokenami/config': patch
+'@tokenami/css': patch
+'@tokenami/dev': patch
+'@tokenami/ts-plugin': patch
+---
+
+Add token delimiter to fix intellisense

--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ The keys in your `responsive` and `theme` objects can be anything you wish. Thes
 With your theme set up, there are only a few rules to remember:
 
 1. A Tokenami **property** is any CSS property prefixed with double dash, e.g. `--font-size`. Use `---` (triple dash) to add custom CSS variables to an element.
-1. A Tokenami **token** is any theme key followed by a value identifier. For example, a `color` object in theme with a `red-100` entry maps to `var(--color-red-100)`.
+1. A Tokenami **token** is any theme key followed by a value identifier, separated by an underscore. For example, a `color` object in theme with a `red-100` entry maps to `var(--color_red-100)`.
 1. Properties can include selectors like media queries, pseudo-classes, and pseudo-elements separated with an underscore. For instance, `--hover_background-color`, `--md_hover_background-color`.
 
 #### Grid values
@@ -253,7 +253,7 @@ module.exports = createConfig({
 Use by following the [token spec](#user-content-styling):
 
 ```tsx
-<div style={{ '--animation': 'var(--anim-wiggle)' }} />
+<div style={{ '--animation': 'var(--anim_wiggle)' }} />
 ```
 
 ## CSS utility
@@ -491,14 +491,14 @@ module.exports = createConfig({
 });
 ```
 
-With this configuration, using `'--content': 'var(--container-half)'` would error because `container` does not exist in the property config for `content`, but `'--content': 'var(--pet-dog)'` would be allowed:
+With this configuration, using `'--content': 'var(--container_half)'` would error because `container` does not exist in the property config for `content`, but `'--content': 'var(--pet_dog)'` would be allowed:
 
 ```tsx
 <div
   style={{
     '--width': 75 /*  300px with a 4px grid */,
-    '--height': 'var(--container-half)',
-    '--after_content': 'var(--pet-cat)',
+    '--height': 'var(--container_half)',
+    '--after_content': 'var(--pet_cat)',
   }}
 />
 ```

--- a/examples/remix/app/root.tsx
+++ b/examples/remix/app/root.tsx
@@ -8,14 +8,14 @@ export const links: LinksFunction = () => [
 
 export default function App() {
   return (
-    <html lang="en" style={{ '--height': 'var(--size-fill)' }}>
+    <html lang="en" style={{ '--height': 'var(--size_fill)' }}>
       <head>
         <meta charSet="utf-8" />
         <meta name="viewport" content="width=device-width,initial-scale=1" />
         <Meta />
         <Links />
       </head>
-      <body style={{ '--min-height': 'var(--size-fill)', '--m': 0, '--p': 0 }}>
+      <body style={{ '--min-height': 'var(--size_fill)', '--m': 0, '--p': 0 }}>
         <Outlet />
         <ScrollRestoration />
         <Scripts />

--- a/examples/remix/app/routes/_index.tsx
+++ b/examples/remix/app/routes/_index.tsx
@@ -10,10 +10,10 @@ export default function Index() {
         '---grid-bg-size': 'calc(var(--grid) * 5)',
         '--background-size': 'var(---,var(---grid-bg-size) var(---grid-bg-size))',
         '--background-image': 'var(---,var(---radial-gradient))',
-        '--background-color': 'var(--color-sky-500)',
+        '--background-color': 'var(--color_sky-500)',
         '--background-position-x': 1,
         '--background-position-y': 0.5,
-        '--height': 'var(--size-screen-h)',
+        '--height': 'var(--size_screen-h)',
         '--display': 'flex',
         '--flex-direction': 'column',
         '--align-items': 'center',
@@ -22,8 +22,8 @@ export default function Index() {
     >
       <figure
         style={{
-          '--bg-color': 'var(--color-slate-100)',
-          '--border-radius': 'var(--radii-rounded)',
+          '--bg-color': 'var(--color_slate-100)',
+          '--border-radius': 'var(--radii_rounded)',
           '--text-align': 'center',
           '--overflow': 'hidden',
           '--m': 10,
@@ -32,7 +32,7 @@ export default function Index() {
           '--md_display': 'flex',
           '--md_p': 0,
           '--md_text-align': 'left',
-          '--font-family': 'var(--font-sans)',
+          '--font-family': 'var(--font_sans)',
           '--line-height': 'var(---,1.8)',
         }}
       >
@@ -58,8 +58,8 @@ export default function Index() {
             </p>
           </blockquote>
           <figcaption style={{ '--font-weight': 'var(---,500)' }}>
-            <div style={{ '--color': 'var(--color-sky-500)' }}>Jenna Smith</div>
-            <div style={{ '--color': 'var(--color-slate-700)' }}>@jjenzz</div>
+            <div style={{ '--color': 'var(--color_sky-500)' }}>Jenna Smith</div>
+            <div style={{ '--color': 'var(--color_slate-700)' }}>@jjenzz</div>
           </figcaption>
         </div>
       </figure>
@@ -68,16 +68,16 @@ export default function Index() {
         style={{
           '--width': 'var(---,180px)',
           '--height': 15,
-          '--border-radius': 'var(--radii-rounded)',
+          '--border-radius': 'var(--radii_rounded)',
           '--border': 'var(---,none)',
-          '--font-family': 'var(--font-sans)',
+          '--font-family': 'var(--font_sans)',
           '--font-size': 'var(---,20px)',
-          '--bg-color': 'var(--color-slate-100)',
-          '--hover_background-color': 'var(--color-slate-700)',
+          '--bg-color': 'var(--color_slate-100)',
+          '--hover_background-color': 'var(--color_slate-700)',
           '--hover_color': 'var(---,white)',
           '--transition': 'var(---,all 150ms)',
-          '--hover_animation': 'var(--anim-wiggle)',
-          '--focus-hover_background-color': 'var(--color-sky-500)',
+          '--hover_animation': 'var(--anim_wiggle)',
+          '--focus-hover_background-color': 'var(--color_sky-500)',
         }}
       >
         Button
@@ -93,12 +93,12 @@ const quoteImage = css(
       circle: {
         '--width': 24,
         '--height': 24,
-        '--border-radius': 'var(--radii-circle)',
+        '--border-radius': 'var(--radii_circle)',
       },
       fill: {
         '--width': 'var(---,11rem)',
-        '--height': 'var(--size-auto)',
-        '--border-radius': 'var(--radii-none)',
+        '--height': 'var(--size_auto)',
+        '--border-radius': 'var(--radii_none)',
       },
     },
   },

--- a/examples/remix/public/tokenami.css
+++ b/examples/remix/public/tokenami.css
@@ -24,20 +24,20 @@
 
 :root {
   --grid: .25rem;
-  --anim-wiggle: wiggle 1s ease-in-out infinite;
-  --color-slate-100: #f1f5f9;
-  --color-slate-700: #334155;
-  --color-sky-500: #0ea5e9;
-  --font-serif: serif;
-  --font-sans: sans-serif;
-  --radii-rounded: 10px;
-  --radii-circle: 9999px;
-  --radii-none: none;
-  --size-auto: auto;
-  --size-fill: 100%;
-  --size-screen-h: 100vh;
-  --pet-cat: "🐱";
-  --pet-dog: "🐶";
+  --anim_wiggle: wiggle 1s ease-in-out infinite;
+  --color_slate-100: #f1f5f9;
+  --color_slate-700: #334155;
+  --color_sky-500: #0ea5e9;
+  --font_serif: serif;
+  --font_sans: sans-serif;
+  --radii_rounded: 10px;
+  --radii_circle: 9999px;
+  --radii_none: none;
+  --size_auto: auto;
+  --size_fill: 100%;
+  --size_screen-h: 100vh;
+  --pet_cat: "🐱";
+  --pet_dog: "🐶";
 }
 
 * {

--- a/packages/config/src/config.ts
+++ b/packages/config/src/config.ts
@@ -10,7 +10,7 @@ function variantProperty(variant: string, name: string): TokenProperty {
 }
 
 function tokenValue<TK extends string, N extends string>(themeKey: TK, name: N): TokenValue<TK, N> {
-  return `var(--${themeKey}-${name})`;
+  return `var(--${themeKey}_${name})`;
 }
 
 function arbitraryValue(value: string): ArbitraryValue {
@@ -18,7 +18,7 @@ function arbitraryValue(value: string): ArbitraryValue {
 }
 
 const tokenPropertyRegex = /--((\w)([\w-]+)?)/;
-const tokenValueRegex = /var\(--(\w+)-([\w-]+)\)/;
+const tokenValueRegex = /var\(--([\w-]+)_([\w-]+)\)/;
 const aritraryValueRegex = /var\(---,(.+)\)/;
 
 type GridValue = z.infer<typeof GridValue>;
@@ -29,7 +29,7 @@ const TokenProperty = z.string().refine((value) => {
   return tokenPropertyRegex.test(value);
 });
 
-type TokenValue<TK extends string = string, V extends string = string> = `var(--${TK}-${V})`;
+type TokenValue<TK extends string = string, V extends string = string> = `var(--${TK}_${V})`;
 const TokenValue = z.string().refine((value) => {
   return tokenValueRegex.test(value);
 });


### PR DESCRIPTION
if a theme contained a `font` object **and** a `font-size` object, a `var(--font-size-2xl)` token would lookup the `font` object in theme bcos it wouldn't know which part of the `var` is the theme key or the value. this delimiter changes the var to `var(--font-size_2xl)` so it can identify the parts appropriately.