### PR TITLE
fix: switch to react type declaration by default

### DIFF
--- a/.changeset/rare-moles-appear.md
+++ b/.changeset/rare-moles-appear.md
@@ -1,0 +1,8 @@
+---
+'@tokenami/config': patch
+'@tokenami/css': patch
+'@tokenami/dev': patch
+'@tokenami/ts-plugin': patch
+---
+
+Switch to react properties declaration by default

--- a/examples/remix/.tokenami/tokenami.d.ts
+++ b/examples/remix/.tokenami/tokenami.d.ts
@@ -7,8 +7,8 @@ declare module '@tokenami/dev' {
   interface TokenamiConfig extends Config {}
 }
 
-declare module 'csstype' {
-  interface Properties extends TokenamiStyles {
-    [customProperty: `---${string}`]: any;
+declare module 'react' {
+  interface CSSProperties extends TokenamiStyles {
+    [customProperty: `---${string}`]: string | number | undefined;
   }
 }

--- a/packages/config/stubs/tokenami.d.ts
+++ b/packages/config/stubs/tokenami.d.ts
@@ -7,8 +7,8 @@ declare module '@tokenami/dev' {
   interface TokenamiConfig extends Config {}
 }
 
-declare module 'csstype' {
-  interface Properties extends TokenamiStyles {
+declare module 'react' {
+  interface CSSProperties extends TokenamiStyles {
     [customProperty: `---${string}`]: string | number | undefined;
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9292,7 +9292,7 @@ packages:
     resolution: {directory: packages/ts-plugin, type: directory}
     id: file:packages/ts-plugin
     name: '@tokenami/ts-plugin'
-    version: 0.0.8-next.0
+    version: 0.0.8-next.2
     peerDependencies:
       '@tokenami/dev': workspace:*
     dependencies:


### PR DESCRIPTION
the `csstype` declaration wasn't working using a vite template. this should work across the board for react projects 🤞 