### PR TITLE
feat: improve css return type

### DIFF
--- a/.changeset/brave-lions-end.md
+++ b/.changeset/brave-lions-end.md
@@ -1,0 +1,8 @@
+---
+'@tokenami/config': patch
+'@tokenami/css': patch
+'@tokenami/dev': patch
+'@tokenami/ts-plugin': patch
+---
+
+Improve css utility return type

--- a/examples/remix/.tokenami/tokenami.d.ts
+++ b/examples/remix/.tokenami/tokenami.d.ts
@@ -1,4 +1,4 @@
-import { TokenamiStyles } from '@tokenami/dev';
+import { TokenamiProperties } from '@tokenami/dev';
 import config from './tokenami.config';
 
 type Config = typeof config;
@@ -8,7 +8,5 @@ declare module '@tokenami/dev' {
 }
 
 declare module 'react' {
-  interface CSSProperties extends TokenamiStyles {
-    [customProperty: `---${string}`]: string | number | undefined;
-  }
+  interface CSSProperties extends TokenamiProperties {}
 }

--- a/packages/config/stubs/tokenami.d.ts
+++ b/packages/config/stubs/tokenami.d.ts
@@ -1,4 +1,4 @@
-import { TokenamiStyles } from '@tokenami/dev';
+import { TokenamiProperties } from '@tokenami/dev';
 import config from './tokenami.config';
 
 type Config = typeof config;
@@ -8,7 +8,5 @@ declare module '@tokenami/dev' {
 }
 
 declare module 'react' {
-  interface CSSProperties extends TokenamiStyles {
-    [customProperty: `---${string}`]: string | number | undefined;
-  }
+  interface CSSProperties extends TokenamiProperties {}
 }

--- a/packages/config/stubs/tokenami.solidjs.d.ts
+++ b/packages/config/stubs/tokenami.solidjs.d.ts
@@ -1,4 +1,4 @@
-import { TokenamiStyles } from '@tokenami/dev';
+import { TokenamiProperties } from '@tokenami/dev';
 import config from './tokenami.config';
 
 type Config = typeof config;
@@ -9,8 +9,6 @@ declare module '@tokenami/dev' {
 
 declare module 'solid-js' {
   namespace JSX {
-    interface CSSProperties extends TokenamiStyles {
-      [customProperty: `---${string}`]: string | number | undefined;
-    }
+    interface CSSProperties extends TokenamiProperties {}
   }
 }

--- a/packages/css/src/css.ts
+++ b/packages/css/src/css.ts
@@ -1,5 +1,5 @@
 import * as Tokenami from '@tokenami/config';
-import type { TokenamiStyles, ResponsiveKey } from '@tokenami/dev';
+import type { TokenamiProperties, ResponsiveKey } from '@tokenami/dev';
 import { mapShorthandToLonghands } from './shorthands';
 
 const SHORTHANDS_TO_LONGHANDS = Symbol.for('tokenamiShorthandToLonghands');
@@ -8,7 +8,7 @@ const SHORTHANDS_TO_LONGHANDS = Symbol.for('tokenamiShorthandToLonghands');
  * css
  * -----------------------------------------------------------------------------------------------*/
 
-type VariantsConfig = Record<string, Record<string, TokenamiStyles>>;
+type VariantsConfig = Record<string, Record<string, TokenamiProperties>>;
 type VariantValue<T> = T extends 'true' | 'false' ? boolean : T;
 type ResponsiveValue<T> = T extends string
   ? ResponsiveKey extends `${infer R}`
@@ -16,7 +16,7 @@ type ResponsiveValue<T> = T extends string
     : never
   : never;
 
-type Override = TokenamiStyles | false | undefined;
+type Override = TokenamiProperties | false | undefined;
 type Variants<C> = { [V in keyof C]?: VariantValue<keyof C[V]> };
 type ResponsiveVariants<C> = {
   [V in keyof C]: { [M in ResponsiveValue<V>]?: VariantValue<keyof C[V]> };
@@ -26,15 +26,17 @@ type SelectedVariants<V, R> = undefined extends V
   ? null
   : Variants<V> & (R extends true ? ResponsiveVariants<V> : {});
 
-function css<S extends TokenamiStyles, V extends VariantsConfig | undefined, R>(
+function css<S extends TokenamiProperties, V extends VariantsConfig | undefined, R>(
   baseStyles: S,
   variantsConfig?: V,
   options?: undefined extends V ? never : { responsive: R & boolean }
 ) {
   const cache: Record<string, Record<string, any>> = {};
 
-  // TODO: return type is `{}` to support both react and solidjs. figure out if this can be improved.
-  return function generate(variants?: SelectedVariants<V, R>, ...overrides: Override[]): {} {
+  return function generate(
+    variants?: SelectedVariants<V, R>,
+    ...overrides: Override[]
+  ): TokenamiProperties {
     const cacheId = JSON.stringify({ variants, overrides });
     const cached = cache[cacheId];
 
@@ -98,7 +100,7 @@ function override(style: Record<string, any>, property: string) {
   }
 }
 
-function convertToMediaStyles(bp: string, styles: TokenamiStyles): TokenamiStyles {
+function convertToMediaStyles(bp: string, styles: TokenamiProperties): TokenamiProperties {
   const updatedEntries = Object.entries(styles).map(([property, value]) => {
     const tokenPrefix = Tokenami.tokenProperty('');
     const bpPrefix = Tokenami.variantProperty(bp, '');

--- a/packages/dev/src/declarations.ts
+++ b/packages/dev/src/declarations.ts
@@ -466,6 +466,8 @@ type TokenamiAliasStyles = {
     : never;
 }[AliasKey];
 
-interface TokenamiStyles extends TokenamiBaseStyles, UnionToIntersection<TokenamiAliasStyles> {}
+interface TokenamiProperties extends TokenamiBaseStyles, UnionToIntersection<TokenamiAliasStyles> {
+  [customProperty: `---${string}`]: string | number | undefined;
+}
 
-export type { TokenamiConfig, TokenamiFinalConfig, TokenamiStyles, ResponsiveKey };
+export type { TokenamiConfig, TokenamiFinalConfig, TokenamiProperties, ResponsiveKey };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9292,7 +9292,7 @@ packages:
     resolution: {directory: packages/ts-plugin, type: directory}
     id: file:packages/ts-plugin
     name: '@tokenami/ts-plugin'
-    version: 0.0.8-next.4
+    version: 0.0.8-next.6
     peerDependencies:
       '@tokenami/dev': workspace:*
     dependencies:


### PR DESCRIPTION
removes ability for consumer to customise `customProperty` format for now cos i'm not entirely sure what they could really customise here. this change allows the `css` utility's `generate` function to return `TokenamiProperties` and it won't error in a react/remix project (which was the original issue).