### PR TITLE
fix: add correct `TokenamiProperties` stubs

### DIFF
--- a/.changeset/fresh-countries-vanish.md
+++ b/.changeset/fresh-countries-vanish.md
@@ -1,0 +1,8 @@
+---
+'@tokenami/config': patch
+'@tokenami/dev': patch
+'@tokenami/css': patch
+'@tokenami/ts-plugin': patch
+---
+
+Add framework specific stubs for TokenamiProperties

--- a/examples/remix/.tokenami/tokenami.d.ts
+++ b/examples/remix/.tokenami/tokenami.d.ts
@@ -5,6 +5,9 @@ type Config = typeof config;
 
 declare module '@tokenami/dev' {
   interface TokenamiConfig extends Config {}
+  interface TokenamiProperties {
+    [customProperty: `---${string}`]: string | number | undefined;
+  }
 }
 
 declare module 'react' {

--- a/packages/config/stubs/tokenami.d.ts
+++ b/packages/config/stubs/tokenami.d.ts
@@ -5,6 +5,9 @@ type Config = typeof config;
 
 declare module '@tokenami/dev' {
   interface TokenamiConfig extends Config {}
+  interface TokenamiProperties {
+    [customProperty: `---${string}`]: string | number | undefined;
+  }
 }
 
 declare module 'react' {

--- a/packages/config/stubs/tokenami.solidjs.d.ts
+++ b/packages/config/stubs/tokenami.solidjs.d.ts
@@ -9,6 +9,8 @@ declare module '@tokenami/dev' {
 
 declare module 'solid-js' {
   namespace JSX {
-    interface CSSProperties extends TokenamiProperties {}
+    interface CSSProperties extends TokenamiProperties {
+      [customProperty: `---${string}`]: string | number | undefined;
+    }
   }
 }

--- a/packages/dev/src/declarations.ts
+++ b/packages/dev/src/declarations.ts
@@ -466,8 +466,6 @@ type TokenamiAliasStyles = {
     : never;
 }[AliasKey];
 
-interface TokenamiProperties extends TokenamiBaseStyles, UnionToIntersection<TokenamiAliasStyles> {
-  [customProperty: `---${string}`]: string | number | undefined;
-}
+interface TokenamiProperties extends TokenamiBaseStyles, UnionToIntersection<TokenamiAliasStyles> {}
 
 export type { TokenamiConfig, TokenamiFinalConfig, TokenamiProperties, ResponsiveKey };


### PR DESCRIPTION
react and solidjs behave differently here so we provide different stubs to allow the `TokenamiProperties` return type from the `css` utility's `generate` function to work correctly.