### PR TITLE
chore: gh action commit permissions

### DIFF
--- a/.github/workflows/prerelease.yaml
+++ b/.github/workflows/prerelease.yaml
@@ -25,6 +25,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
+          token: ${{ secrets.PAT }}
 
       - name: 🏗 Setup repository
         uses: ./.github/actions/setup-repo

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -22,6 +22,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
+          token: ${{ secrets.PAT }}
 
       - name: 🏗 Setup repository
         uses: ./.github/actions/setup-repo


### PR DESCRIPTION
branch protection has been added since making repository public, so need to give `stefanzweifel/git-auto-commit-action@v5` permissions to commit to `main`.