### PR TITLE
fix: add responsive+selector types for ci

### DIFF
--- a/.changeset/healthy-peaches-sort.md
+++ b/.changeset/healthy-peaches-sort.md
@@ -1,0 +1,8 @@
+---
+'@tokenami/dev': patch
+'@tokenami/config': patch
+'@tokenami/css': patch
+'@tokenami/ts-plugin': patch
+---
+
+Add responsive+selector types for CI

--- a/examples/remix/app/routes/_index.tsx
+++ b/examples/remix/app/routes/_index.tsx
@@ -78,6 +78,7 @@ export default function Index() {
           '--transition': 'var(---,all 150ms)',
           '--hover_animation': 'var(--anim_wiggle)',
           '--focus-hover_background-color': 'var(--color_sky-500)',
+          '--md_focus-hover_background-color': 'var(--color_slate-700)',
         }}
       >
         Button

--- a/examples/remix/public/tokenami.css
+++ b/examples/remix/public/tokenami.css
@@ -290,6 +290,10 @@
 }
 
 @media (min-width: 700px) {
+  [style*="--md_focus-hover_background-color:"]:focus:hover {
+    background-color: var(--md_focus-hover_background-color, var(--background-color));
+  }
+
   [style*="--md_border-radius:"] {
     border-radius: var(--md_border-radius, var(--border-radius));
   }

--- a/packages/dev/src/declarations.ts
+++ b/packages/dev/src/declarations.ts
@@ -25,13 +25,6 @@ type ThemePropertyValue<ThemeKey> = ThemeKey extends 'grid'
   ? TokenVar<ThemeKey> | Tokenami.ArbitraryValue | Tokenami.GridValue
   : TokenVar<ThemeKey> | Tokenami.ArbitraryValue;
 
-type TokenName<ThemeKey> = ThemeKey extends keyof ThemeConfig ? keyof ThemeConfig[ThemeKey] : never;
-type TokenVar<ThemeKey> = ThemeKey extends string
-  ? TokenName<ThemeKey> extends `${infer Token}`
-    ? Tokenami.TokenValue<ThemeKey, Token>
-    : never
-  : never;
-
 type PropertyValue<P> = P extends keyof PropertyConfig
   ? PropertyConfig[P][number] extends infer ThemeKey
     ? ThemeKey extends never
@@ -40,8 +33,21 @@ type PropertyValue<P> = P extends keyof PropertyConfig
     : never
   : CSSPropertyValue<P>;
 
+type TokenName<ThemeKey> = ThemeKey extends keyof ThemeConfig ? keyof ThemeConfig[ThemeKey] : never;
+type TokenVar<ThemeKey> = ThemeKey extends string
+  ? TokenName<ThemeKey> extends `${infer Token}`
+    ? Tokenami.TokenValue<ThemeKey, Token>
+    : never
+  : never;
+
+type SelectorVariantStyle<P extends string, V> = {
+  [key in Tokenami.TokenProperty<
+    `${ResponsiveKey}_${P}` | `${SelectorsKey}_${P}` | `${ResponsiveKey}_${SelectorsKey}_${P}`
+  >]?: V;
+};
+
 type VariantStyle<P extends string, V> = TokenamiFinalConfig['CI'] extends true
-  ? { [key in Tokenami.TokenProperty<`${ResponsiveKey}_${P}` | `${SelectorsKey}_${P}`>]?: V }
+  ? SelectorVariantStyle<P, V>
   : { [key in Tokenami.TokenProperty<`${string}_${P}`>]: V };
 
 type TokenamiStyle<P extends string, V = PropertyValue<P>> = VariantStyle<P, V> & {


### PR DESCRIPTION
i recently added CI support for types but forgot to add responsive+selector types so `--md_hover_color` would fail a typecheck during CI. this fixes that.