### PR TITLE
feat: avoid generating redundant `var` selectors

### DIFF
--- a/.changeset/small-parrots-join.md
+++ b/.changeset/small-parrots-join.md
@@ -1,0 +1,8 @@
+---
+'@tokenami/config': patch
+'@tokenami/dev': patch
+'@tokenami/css': patch
+'@tokenami/ts-plugin': patch
+---
+
+Only generate `var` selectors when used

--- a/examples/remix/package.json
+++ b/examples/remix/package.json
@@ -5,10 +5,11 @@
   "sideEffects": false,
   "scripts": {
     "prepare": "tokenami",
-    "build": "tokenami --minify && remix build",
+    "build": "pnpm build:css --minify && remix build",
+    "build:css": "tokenami",
     "dev": "concurrently \"pnpm:dev:*\"",
     "dev:app": "remix dev",
-    "dev:css": "tokenami --watch",
+    "dev:css": "pnpm build:css --watch",
     "start": "remix-serve build",
     "typecheck": "tsc --noEmit",
     "typecheck:ci": "tsc --noEmit --project tsconfig.ci.json",

--- a/examples/remix/public/tokenami.css
+++ b/examples/remix/public/tokenami.css
@@ -131,14 +131,6 @@
   border: var(--border);
 }
 
-[style*="--border-right-width:"] {
-  border-right-width: calc(var(--grid) * var(--border-right-width));
-}
-
-[style*="--border-left-width:"] {
-  border-left-width: calc(var(--grid) * var(--border-left-width));
-}
-
 [style*="--border-radius:"] {
   border-radius: var(--border-radius);
 }
@@ -197,10 +189,6 @@
   margin-left: calc(var(--grid) * var(--margin-left));
 }
 
-[style*="--min-height:"] {
-  min-height: calc(var(--grid) * var(--min-height));
-}
-
 [style*="--object-fit:"] {
   object-fit: var(--object-fit);
 }
@@ -209,23 +197,23 @@
   overflow: var(--overflow);
 }
 
-[style*="--p:"], [style*="--padding:"] {
+[style*="--p:"] {
   padding: calc(var(--grid) * var(--padding));
 }
 
-[style*="--py:"], [style*="--pt:"], [style*="--padding-top:"] {
+[style*="--py:"], [style*="--pt:"] {
   padding-top: calc(var(--grid) * var(--padding-top));
 }
 
-[style*="--px:"], [style*="--padding-right:"] {
+[style*="--px:"] {
   padding-right: calc(var(--grid) * var(--padding-right));
 }
 
-[style*="--py:"], [style*="--padding-bottom:"] {
+[style*="--py:"] {
   padding-bottom: calc(var(--grid) * var(--padding-bottom));
 }
 
-[style*="--px:"], [style*="--padding-left:"], [style*="--pl:"] {
+[style*="--px:"], [style*="--pl:"] {
   padding-left: calc(var(--grid) * var(--padding-left));
 }
 
@@ -250,14 +238,6 @@
   width: calc(var(--grid) * var(--width));
 }
 
-[style*="--background-position-x:var"], [style*="--background-position-x: var"] {
-  background-position-x: var(--background-position-x);
-}
-
-[style*="--background-position-y:var"], [style*="--background-position-y: var"] {
-  background-position-y: var(--background-position-y);
-}
-
 [style*="--border-right-width:var"], [style*="--border-right-width: var"] {
   border-right-width: var(--border-right-width);
 }
@@ -270,43 +250,27 @@
   height: var(--height);
 }
 
-[style*="--m:var"], [style*="--m: var"] {
-  margin: var(--margin);
-}
-
-[style*="--mx:var"], [style*="--mx: var"] {
-  margin-right: var(--margin-right);
-}
-
-[style*="--mb:var"], [style*="--mb: var"] {
-  margin-bottom: var(--margin-bottom);
-}
-
-[style*="--mx:var"], [style*="--mx: var"], [style*="--ml:var"], [style*="--ml: var"] {
-  margin-left: var(--margin-left);
-}
-
 [style*="--min-height:var"], [style*="--min-height: var"] {
   min-height: var(--min-height);
 }
 
-[style*="--p:var"], [style*="--p: var"], [style*="--padding:var"], [style*="--padding: var"] {
+[style*="--padding:var"], [style*="--padding: var"] {
   padding: var(--padding);
 }
 
-[style*="--py:var"], [style*="--py: var"], [style*="--pt:var"], [style*="--pt: var"], [style*="--padding-top:var"], [style*="--padding-top: var"] {
+[style*="--padding-top:var"], [style*="--padding-top: var"] {
   padding-top: var(--padding-top);
 }
 
-[style*="--px:var"], [style*="--px: var"], [style*="--padding-right:var"], [style*="--padding-right: var"] {
+[style*="--padding-right:var"], [style*="--padding-right: var"] {
   padding-right: var(--padding-right);
 }
 
-[style*="--py:var"], [style*="--py: var"], [style*="--padding-bottom:var"], [style*="--padding-bottom: var"] {
+[style*="--padding-bottom:var"], [style*="--padding-bottom: var"] {
   padding-bottom: var(--padding-bottom);
 }
 
-[style*="--px:var"], [style*="--px: var"], [style*="--padding-left:var"], [style*="--padding-left: var"], [style*="--pl:var"], [style*="--pl: var"] {
+[style*="--padding-left:var"], [style*="--padding-left: var"] {
   padding-left: var(--padding-left);
 }
 
@@ -349,10 +313,6 @@
 
   [style*="--md_height:var"], [style*="--md_height: var"] {
     height: var(--md_height, var(--height));
-  }
-
-  [style*="--md_p:var"], [style*="--md_p: var"] {
-    padding: var(--md_p, var(--padding));
   }
 
   [style*="--md_width:var"], [style*="--md_width: var"] {

--- a/packages/config/src/config.ts
+++ b/packages/config/src/config.ts
@@ -21,9 +21,11 @@ const tokenPropertyRegex = /(?<!var\()--((\w)([\w-]+)?)/;
 const variantPropertyRegex = /(?<!var\()--((\w)([\w-]+)_([\w-]+))/;
 const tokenValueRegex = /var\(--([\w-]+)_([\w-]+)\)/;
 const aritraryValueRegex = /var\(---,(.+)\)/;
+const gridValueRegex = /^\d+/;
 
-type GridValue = v.Output<typeof gridValueSchema>;
-const gridValueSchema = v.number();
+type GridValue = number;
+const gridValueRegexSchema = v.regex(gridValueRegex);
+const gridValueSchema = v.string([gridValueRegexSchema]);
 const GridValue = { safeParse: (input: unknown) => v.safeParse(gridValueSchema, input) };
 
 type TokenProperty<P extends string = string> = `--${P}`;
@@ -46,7 +48,11 @@ const tokenValueSchema = v.string([tokenValueRegexSchema]) as v.StringSchema<Tok
 const TokenValue = { safeParse: (input: unknown) => v.safeParse(tokenValueSchema, input) };
 
 type ArbitraryValue = `var(---,${string})`;
-const ArbitraryValue = v.string([v.regex(aritraryValueRegex)]);
+const arbitraryValueRegexSchema = v.regex(aritraryValueRegex);
+const arbitraryValueSchema = v.string([
+  arbitraryValueRegexSchema,
+]) as v.StringSchema<ArbitraryValue>;
+const ArbitraryValue = { safeParse: (input: unknown) => v.safeParse(arbitraryValueSchema, input) };
 
 type ThemeKey =
   | 'alpha'

--- a/packages/dev/package.json
+++ b/packages/dev/package.json
@@ -35,6 +35,7 @@
     "chalk": "^5.2.0",
     "chokidar": "^3.5.3",
     "csstype": "^3.1.2",
+    "deepmerge": "^4.3.1",
     "fast-glob": "^3.2.12",
     "inquirer": "^9.2.12",
     "jiti": "^1.21.0",

--- a/packages/dev/src/utils/common.ts
+++ b/packages/dev/src/utils/common.ts
@@ -96,7 +96,7 @@ function getValuesByTokenValueProperty(used: Tokenami.TokenValue[], theme: Token
     const [tokenValueProperty] = tokenValue.match(/--[\w-]+/) || [];
     const value = theme[parts.themeKey]?.[parts.token];
     if (!tokenValueProperty || value == null) return [];
-    return [[tokenValueProperty, value]] as [[string, typeof value]];
+    return [[tokenValueProperty, value]] as const;
   });
   // make rules a deterministic order (theme key order) instead of usage order
   const sorted = entries.sort((a, b) => themeKeys.indexOf(a[0]) - themeKeys.indexOf(b[0]));

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -137,6 +137,9 @@ importers:
       csstype:
         specifier: ^3.1.2
         version: 3.1.3
+      deepmerge:
+        specifier: ^4.3.1
+        version: 4.3.1
       fast-glob:
         specifier: ^3.2.12
         version: 3.3.2
@@ -4188,7 +4191,6 @@ packages:
   /deepmerge@4.3.1:
     resolution: {integrity: sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==}
     engines: {node: '>=0.10.0'}
-    dev: true
 
   /defaults@1.0.4:
     resolution: {integrity: sha512-eFuaLoy/Rxalv2kr+lqMlUnrDWV+3j4pljOIJgLIhI058IQfWJ7vXhyEIHu+HtC738klGALYxOKDO0bQP3tg8A==}


### PR DESCRIPTION
makes sure `grid` properties only generate stylesheet rules associated with value types that are actually being used. for example, `--p: var(---,20px)` will generate the `[style*="--p: var"]` selector and `--p: 2` will generate `[style*="--p"]` with `calc` rule.

the `: var` selectors are less than ideal perf-wise, but i'm hoping [an `apply` api](https://github.com/tokenami/tokenami/issues/182) can help with some of the perf concerns here.