### PR TITLE
feat: add `Pick` and `Omit` utility types

### DIFF
--- a/.changeset/long-cups-boil.md
+++ b/.changeset/long-cups-boil.md
@@ -1,0 +1,8 @@
+---
+'@tokenami/dev': patch
+'@tokenami/config': patch
+'@tokenami/css': patch
+'@tokenami/ts-plugin': patch
+---
+
+Add `Pick` and `Omit` utility types for `TokenamiProperties`

--- a/packages/dev/src/declarations.ts
+++ b/packages/dev/src/declarations.ts
@@ -489,4 +489,18 @@ interface TokenamiProperties extends Properties {
   [customProperty: `---${string}`]: string | number | undefined;
 }
 
-export type { TokenamiConfig, TokenamiFinalConfig, TokenamiProperties };
+type TokenamiPropertiesPick<P extends keyof Property> = Pick<Property, P> extends infer T
+  ? T[keyof T]
+  : never;
+
+type TokenamiPropertiesOmit<P extends keyof Property> = Omit<Property, P> extends infer T
+  ? T[keyof T]
+  : never;
+
+export type {
+  TokenamiConfig,
+  TokenamiFinalConfig,
+  TokenamiProperties,
+  TokenamiPropertiesPick,
+  TokenamiPropertiesOmit,
+};


### PR DESCRIPTION
Closes #186


```tsx
import { TokenamiPropertiesPick, TokenamiPropertiesOmit } from '@tokenami/dev';

type OnlyGrid = TokenamiPropertiesPick<'grid'>;
type WithoutGrid = TokenamiPropertiesOmit<'grid'>;

// ok
export const a: OnlyGrid = {
  '--grid': '',
};

// ok
export const b: WithoutGrid = {
  '--color': '',
};

// error
export const c: OnlyGrid = {
  '--grid': '',
  '--color': '',
};

// error
export const d: WithoutGrid = {
  '--grid': '',
  '--color': '',
};
```