### PR TITLE
fix: correct the unused layers regex for prod builds

### DIFF
--- a/.changeset/tall-onions-give.md
+++ b/.changeset/tall-onions-give.md
@@ -1,0 +1,8 @@
+---
+'@tokenami/dev': patch
+'@tokenami/config': patch
+'@tokenami/css': patch
+'@tokenami/ts-plugin': patch
+---
+
+Fix the unused layers regex for production builds

--- a/packages/dev/src/sheet.ts
+++ b/packages/dev/src/sheet.ts
@@ -11,7 +11,7 @@ const LAYER = {
 };
 
 const LAYERS = Object.values(LAYER);
-const UNUSED_LAYERS_REGEX = /[\n]?@layer .+;[\n]?/g;
+const UNUSED_LAYERS_REGEX = /[\n]?@layer[a-z-,\s]+;[\n]?/g;
 
 type PropertyConfig = ReturnType<typeof Tokenami.getTokenPropertyParts> & {
   order: number;


### PR DESCRIPTION
the original regex was a bit too keen 😅  when the CSS was minified, it would replace the entire sheet past an instance of `@layer` with an empty string. this fixes that.