### PR TITLE
fix: remove wide record type from css util

### DIFF
--- a/.changeset/big-tools-protect.md
+++ b/.changeset/big-tools-protect.md
@@ -1,0 +1,8 @@
+---
+'@tokenami/css': patch
+'@tokenami/dev': patch
+'@tokenami/config': patch
+'@tokenami/ts-plugin': patch
+---
+
+Remove wide record type from css util

--- a/packages/css/src/css.ts
+++ b/packages/css/src/css.ts
@@ -12,7 +12,7 @@ type VariantValue<T> = T extends 'true' | 'false' ? boolean : T;
 type ReponsiveKey = Extract<keyof TokenamiFinalConfig['responsive'], string>;
 type ResponsiveValue<T> = T extends string ? `${ReponsiveKey}_${T}` : never;
 
-type Override = TokenamiProperties | Record<string, any> | false | undefined;
+type Override = TokenamiProperties | false | undefined;
 type Variants<C> = { [V in keyof C]?: VariantValue<keyof C[V]> };
 type ResponsiveVariants<C> = {
   [V in keyof C]: { [M in ResponsiveValue<V>]?: VariantValue<keyof C[V]> };


### PR DESCRIPTION
i was originally testing some things and left this in by mistake. 

i was exploring whether `css` should allow `React.CSSProperties` since we can't style directly in style anymore but i think we can see if people request that. ppl can do this instead at the end of the day:

```tsx
style={{ padding: '20px', ...css({ '--m': 2 }) }}
```