### PR TITLE
fix: `getTokenPropertyParts` fix for invalid/valid selector combos

### DIFF
--- a/.changeset/tough-emus-peel.md
+++ b/.changeset/tough-emus-peel.md
@@ -1,0 +1,8 @@
+---
+'@tokenami/config': patch
+'@tokenami/css': patch
+'@tokenami/dev': patch
+'@tokenami/ts-plugin': patch
+---
+
+Fix `getTokenPropertyParts` when there is an invalid/valid selector combination

--- a/packages/config/src/config.ts
+++ b/packages/config/src/config.ts
@@ -128,7 +128,7 @@ function getTokenPropertyParts(tokenProperty: TokenProperty, config: Config): Pr
   const [alias, ...variants] = name.split('_').reverse() as [string, ...(string | undefined)[]];
   const [v1, v2, ...invalidVariants] = variants.reverse();
   const responsive = config.responsive?.[v1!] && v1;
-  const selector = (config.selectors?.[v1!] && v1) || (config.selectors?.[v2!] && v2);
+  const selector = responsive ? config.selectors?.[v2!] && v2 : config.selectors?.[v1!] && v1;
   const hasInvalidVariant = v1 && !responsive && !selector;
   const variant = [responsive, selector].filter(Boolean).join('_');
   if (invalidVariants.length || hasInvalidVariant) return null;


### PR DESCRIPTION
Fixes #196