### PR TITLE
feat: improve DX for variants/responsive variants

### DIFF
--- a/.changeset/tame-shirts-remember.md
+++ b/.changeset/tame-shirts-remember.md
@@ -1,0 +1,8 @@
+---
+'@tokenami/css': patch
+'@tokenami/dev': patch
+'@tokenami/config': patch
+'@tokenami/ts-plugin': patch
+---
+
+Improve variants/responsive variants API

--- a/examples/remix/app/routes/_index.tsx
+++ b/examples/remix/app/routes/_index.tsx
@@ -117,9 +117,10 @@ export default function Index() {
   );
 }
 
-const quoteImage = css.compose(
-  { '--object-fit': 'cover' },
-  {
+const quoteImage = css.compose({
+  '--object-fit': 'cover',
+
+  responsiveVariants: {
     variant: {
       circle: {
         '--width': 24,
@@ -133,5 +134,4 @@ const quoteImage = css.compose(
       },
     },
   },
-  { responsive: true }
-);
+});

--- a/examples/remix/app/routes/css.tsx
+++ b/examples/remix/app/routes/css.tsx
@@ -2,9 +2,10 @@ import { css } from '~/css';
 
 export const links = () => [{ rel: 'stylesheet', href: '/tokenami.css' }];
 
-const button = css.compose(
-  { '--all': 'unset' },
-  {
+const button = css.compose({
+  '--all': 'unset',
+
+  variants: {
     size: {
       small: {
         '--padding-top': 'var(---,3px)',
@@ -18,8 +19,8 @@ const button = css.compose(
         '--border': 'var(---,3px solid red)',
       },
     },
-  }
-);
+  },
+});
 
 export default function Index() {
   return (

--- a/examples/remix/public/tokenami.css
+++ b/examples/remix/public/tokenami.css
@@ -85,14 +85,6 @@
   --mb: initial;
   --ml: initial;
   --min-height: initial;
-  --_1883ll6: var(--md) var(--md_object-fit);
-  --md_object-fit: initial;
-  --_1j7l71u: var(--lg) var(--lg_object-fit);
-  --lg_object-fit: initial;
-  --_1abk9c9: var(--xl) var(--xl_object-fit);
-  --xl_object-fit: initial;
-  --_10dq7t9: var(--2xl) var(--2xl_object-fit);
-  --2xl_object-fit: initial;
   --object-fit: initial;
   --overflow: initial;
   --_1tfdub6: var(--md) var(--md_padding, var(--md_p));
@@ -192,7 +184,6 @@
     display: var(--_cbroqb, var(--display, revert-layer));
     font-size: var(--_1qfo97, var(--font-size, revert-layer));
     height: var(--_18bne5j, var(--_131ipn5, var(--_midacu, var(--_1hvgbk2, var(--height, revert-layer)))));
-    object-fit: var(--_10dq7t9, var(--_1abk9c9, var(--_1j7l71u, var(--_1883ll6, var(--object-fit, revert-layer)))));
     text-align: var(--_1hooa64, var(--text-align, revert-layer));
     width: var(--_lgvp90, var(--_1qgla5e, var(--_3q4l9b, var(--_rmk1kf, var(--width, revert-layer)))));
   }

--- a/packages/css/src/test/compose.test.ts
+++ b/packages/css/src/test/compose.test.ts
@@ -7,45 +7,43 @@ import { css, convertToMediaStyles } from '../css';
  * -----------------------------------------------------------------------------------------------*/
 
 // freeze configs to ensure tests fail if `css` mutates them
-
 const baseStyles = Object.freeze({
   '--padding': '10px',
   '--md_padding': 2,
   '--border': '1px solid',
-}) as any;
+}) as {};
 
-const baseStylesOutput = {
+const baseStylesOutput = Object.freeze({
   ...baseStyles,
   '--md_padding': 'calc(var(--_grid) * 2)',
-};
+}) as {};
 
 const disabledStyles = Object.freeze({
   '--font-weight': 'normal',
-}) as any;
+}) as {};
 
 const enabledStyles = Object.freeze({
   '--font-weight': 'bold',
-}) as any;
+}) as {};
 
 const primaryStyles = Object.freeze({
   '--color': 'violet',
   '--border-color': 'darkviolet',
-}) as any;
+}) as {};
 
 const secondaryStyles = Object.freeze({
   '--color': 'gray',
   '--border-color': 'lightgray',
   '--font-family': 'serif',
-}) as any;
+}) as {};
 
-const button = css.compose(
-  baseStyles,
-  {
+const button = css.compose({
+  ...baseStyles,
+  responsiveVariants: {
     disabled: { true: disabledStyles, false: enabledStyles },
     type: { primary: primaryStyles, secondary: secondaryStyles },
   },
-  { responsive: true }
-);
+});
 
 /* -------------------------------------------------------------------------------------------------
  * tests

--- a/packages/dev/package.json
+++ b/packages/dev/package.json
@@ -30,6 +30,8 @@
   "dependencies": {
     "@stitches/stringify": "^1.2.8",
     "@tokenami/config": "workspace:*",
+    "acorn": "^8.11.3",
+    "acorn-walk": "^8.3.2",
     "browserslist": "^4.22.2",
     "cac": "^6.7.14",
     "chalk": "^5.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -122,6 +122,12 @@ importers:
       '@tokenami/config':
         specifier: workspace:*
         version: link:../config
+      acorn:
+        specifier: ^8.11.3
+        version: 8.11.3
+      acorn-walk:
+        specifier: ^8.3.2
+        version: 8.3.2
       browserslist:
         specifier: ^4.22.2
         version: 4.22.2
@@ -3268,11 +3274,15 @@ packages:
     engines: {node: '>=0.4.0'}
     dev: true
 
+  /acorn-walk@8.3.2:
+    resolution: {integrity: sha512-cjkyv4OtNCIeqhHrfS81QWXoCBPExR/J62oyEqepVw8WaQeSqpW2uhuLPh1m9eWhDuOo/jUXVTlifvesOWp/4A==}
+    engines: {node: '>=0.4.0'}
+    dev: false
+
   /acorn@8.11.3:
     resolution: {integrity: sha512-Y9rRfJG5jcKOE0CLisYbojUjIrIEE7AGMzA/Sm4BslANhbS+cDMpgBdcPT91oJ7OuJ9hYJBx59RjbhxVnrF8Xg==}
     engines: {node: '>=0.4.0'}
     hasBin: true
-    dev: true
 
   /agent-base@7.1.0:
     resolution: {integrity: sha512-o/zjMZRhJxny7OyEF+Op8X+efiELC7k7yOjMzgfzVqOzXqkBkWI79YoTdOtsuWd5BWhAGAuOY/Xa6xpiaWXiNg==}


### PR DESCRIPTION
- Improves the DX for authoring variants and responsive variants in the `css.compose` api. 
- Fixes a bug where `responsive: true` would generate the responsive styles for the base styles also and not just the properties within the variants object.


The new API looks as follows:

```tsx
const button = css.compose({
  '---padding': 4,

  variants: {
    size: {
      small: { '--padding': 2 },
      large: { '--padding': 6 },
    },
  },
});
```

to enable responsive variants, apply the following changes:

```diff
const button = css.compose({
  '---padding': 4,

-  variants: {
+  responsiveVariants: {
    size: {
      small: { '--padding': 2 },
      large: { '--padding': 6 },
    },
  },
});
```