### PR TITLE
fix: remove `all` from shorthands to prevent max callstack error

### DIFF
--- a/.changeset/thick-adults-glow.md
+++ b/.changeset/thick-adults-glow.md
@@ -1,0 +1,8 @@
+---
+'@tokenami/config': patch
+'@tokenami/css': patch
+'@tokenami/dev': patch
+'@tokenami/ts-plugin': patch
+---
+
+Remove `all` from shorthands to prevent max callstack error

--- a/packages/config/src/shorthands.ts
+++ b/packages/config/src/shorthands.ts
@@ -1,7 +1,7 @@
-import { type CSSProperty, properties } from './supports';
+import { type CSSProperty } from './supports';
 
 const mapShorthandToLonghands = {
-  all: properties.filter((property) => property === 'all'),
+  all: [],
   animation: [
     'animation-name',
     'animation-duration',


### PR DESCRIPTION
i added this solution a bit haphazardly before and have noticed that this solution would actually cause a max callstack error. 

i need to spend some proper focused time on a solution for `--all` passed as an override. for now, i'll wait to see if i get requests for it to determine how necessary it is.

this will also reduce the size of the `css` bundle which i'd like to minimise where possible.