### PR TITLE
refactor: remove `csstype` from `css` util

### DIFF
--- a/.changeset/strong-ears-appear.md
+++ b/.changeset/strong-ears-appear.md
@@ -1,0 +1,8 @@
+---
+'@tokenami/css': patch
+'@tokenami/config': patch
+'@tokenami/dev': patch
+'@tokenami/ts-plugin': patch
+---
+
+Remove `csstype` from `css` util

--- a/packages/css/package.json
+++ b/packages/css/package.json
@@ -20,8 +20,7 @@
     "test:watch": "vitest"
   },
   "dependencies": {
-    "@tokenami/config": "workspace:*",
-    "csstype": "^3.1.3"
+    "@tokenami/config": "workspace:*"
   },
   "devDependencies": {
     "@tokenami/dev": "workspace:*",

--- a/packages/css/src/css.ts
+++ b/packages/css/src/css.ts
@@ -1,12 +1,7 @@
-import type * as CSSType from 'csstype';
 import type { TokenamiProperties, TokenamiFinalConfig } from '@tokenami/dev';
 import * as Tokenami from '@tokenami/config';
 
 const _ALIASES = Symbol();
-
-type Properties = { [K in keyof CSSType.Properties]: any } & {
-  [K in keyof CSSType.PropertiesHyphen]: any;
-};
 
 /* -------------------------------------------------------------------------------------------------
  * css
@@ -17,7 +12,7 @@ type VariantValue<T> = T extends 'true' | 'false' ? boolean : T;
 type ReponsiveKey = Extract<keyof TokenamiFinalConfig['responsive'], string>;
 type ResponsiveValue<T> = T extends string ? `${ReponsiveKey}_${T}` : never;
 
-type Override = TokenamiProperties | Properties | false | undefined;
+type Override = TokenamiProperties | false | undefined;
 
 type Variants<C> = undefined extends C ? {} : { [V in keyof C]?: VariantValue<keyof C[V]> };
 type ResponsiveVariants<C> = undefined extends C

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -96,9 +96,6 @@ importers:
       '@tokenami/config':
         specifier: workspace:*
         version: link:../config
-      csstype:
-        specifier: ^3.1.3
-        version: 3.1.3
     devDependencies:
       '@tokenami/dev':
         specifier: workspace:*


### PR DESCRIPTION
this is a tricky problem to solve. we need people to be able to do this:

```tsx
function Button(prop: React.ComponentProps<'button'>) {
  return <button style={css({ /* styles */ }, props.style)} />
}
```

note the `props.style` passed to `css`. the types required to allow this are different in different frameworks e.g. `PropertiesStandard` or `PropertiesHyphen`. also, typing overrides appropriately for the specific frameworks would enable intellisense in the overrides which likely isn't the desired DX.

i'm reverting this change for now while we think some more on a solution for this (i'd prefer to avoid lib specific workarounds if possible). in the meantime, component authors can use `style.props as any` to silence the type system.

```tsx
function Button(prop: React.ComponentProps<'button'>) {
  return <button style={css({ /* styles */ }, props.style as any)} />
}
```