### PR TITLE
refactor: remove supported properties from `css` bundle

### DIFF
--- a/.changeset/tall-jokes-cheer.md
+++ b/.changeset/tall-jokes-cheer.md
@@ -1,0 +1,8 @@
+---
+'@tokenami/config': patch
+'@tokenami/css': patch
+'@tokenami/dev': patch
+'@tokenami/ts-plugin': patch
+---
+
+Remove supported properties from css bundle to reduce its bundle size

--- a/packages/config/src/config.ts
+++ b/packages/config/src/config.ts
@@ -128,7 +128,7 @@ type ThemeKey =
 
 type ThemeValues = Record<string, string>;
 type Theme = Partial<Record<ThemeKey, ThemeValues>>;
-type Aliases = Record<string, readonly (Supports.CSSProperty | (string & {}))[]>;
+type Aliases = Record<string, readonly Supports.CSSProperty[]>;
 type PropertiesOptions = readonly ('grid' | ThemeKey)[];
 
 type DeepReadonly<T> = {
@@ -219,11 +219,11 @@ function getTokenValueParts(tokenValue: TokenValue) {
  * and `padding-right`, so this gets an array of CSS properties for a given alias.
  * -----------------------------------------------------------------------------------------------*/
 
-function getCSSPropertiesForAlias(alias: string, aliases: Config['aliases']) {
-  const longhands: string[] = (aliases as any)?.[alias];
-  const result = longhands || [alias];
-  const valid = result.filter((property) => Supports.properties.includes(property as any));
-  return valid as Supports.CSSProperty[];
+function getCSSPropertiesForAlias(
+  alias: string,
+  aliases: Config['aliases']
+): Supports.CSSProperty[] {
+  return (aliases as any)?.[alias] || [alias];
 }
 
 /* ---------------------------------------------------------------------------------------------- */

--- a/packages/css/src/test/create.test.ts
+++ b/packages/css/src/test/create.test.ts
@@ -21,16 +21,18 @@ describe('css returned from createCss', () => {
   describe('when invoked with alias override', () => {
     beforeEach<TestContext>((context) => {
       const css = createCss({
+        include: [],
+        theme: {},
         aliases: {
           p: ['padding'],
-          px: ['padding-left', 'padding-right', 'invalid'],
-          py: ['padding-top', 'padding-bottom', 'invalid'],
+          px: ['padding-left', 'padding-right'],
+          py: ['padding-top', 'padding-bottom'],
           pt: ['padding-top'],
           pr: ['padding-right'],
           pb: ['padding-bottom'],
           pl: ['padding-left'],
         },
-      } as any);
+      });
 
       context.output = css(
         {
@@ -71,16 +73,18 @@ describe('css returned from createCss', () => {
     describe('when invoked with reordered aliases', () => {
       beforeEach<TestContext>((context) => {
         const css = createCss({
+          include: [],
+          theme: {},
           aliases: {
             pt: ['padding-top'],
             pr: ['padding-right'],
             pb: ['padding-bottom'],
             pl: ['padding-left'],
-            p: ['invalid', 'padding'],
+            p: ['padding'],
             px: ['padding-left', 'padding-right'],
             py: ['padding-top', 'padding-bottom'],
           },
-        } as any);
+        });
 
         context.outputReorderedAliases = css(
           {
@@ -101,16 +105,18 @@ describe('css returned from createCss', () => {
   describe('when invoked with reordered alias longhands', () => {
     beforeEach<TestContext>((context) => {
       const css = createCss({
+        include: [],
+        theme: {},
         aliases: {
           p: ['padding'],
-          px: ['invalid', 'padding-left', 'padding-right'],
-          py: ['invalid', 'padding-top', 'padding-bottom'],
+          px: ['padding-left', 'padding-right'],
+          py: ['padding-top', 'padding-bottom'],
           pt: ['padding-top'],
           pr: ['padding-right'],
           pb: ['padding-bottom'],
           pl: ['padding-left'],
         },
-      } as any);
+      });
 
       // @ts-expect-error tests don't have `tokenami.d.ts` so aliases will error here.
       context.output = css({ '--pr': '10px', '--pl': '30px' }, { '--px': 20 });


### PR DESCRIPTION
Now that aliases can only be valid css properties, we can type the alias property in the config to reflect that so we don't need to validate in `getCSSPropertiesForAlias`. the `css` utilities uses `getCSSPropertiesForAlias` so this change reduces the impact on `css` bundle size.