### PR TITLE
feat: allow `inherit` value in any property to inherit from parent

### DIFF
--- a/.changeset/five-icons-hang.md
+++ b/.changeset/five-icons-hang.md
@@ -1,0 +1,8 @@
+---
+'@tokenami/dev': patch
+'@tokenami/config': patch
+'@tokenami/css': patch
+'@tokenami/ts-plugin': patch
+---
+
+Allow all CSS properties to be inheritable properties

--- a/examples/remix/.tokenami/tokenami.config.ts
+++ b/examples/remix/.tokenami/tokenami.config.ts
@@ -18,6 +18,9 @@ export default createConfig({
       'slate-700': '#334155',
       'sky-500': '#0ea5e9',
     },
+    border: {
+      thin: '1px solid var(--color_slate-700)',
+    },
     font: {
       serif: 'serif',
       sans: 'sans-serif',

--- a/examples/remix/app/routes/_index.tsx
+++ b/examples/remix/app/routes/_index.tsx
@@ -72,6 +72,19 @@ export default function Index() {
         </div>
       </figure>
 
+      <div style={css({ '--mb': 5, '--p': 5, '--border': 'var(--border_thin)' })}>
+        boop
+        <div
+          style={css({
+            '--p': 'inherit',
+            '--background-color': 'var(--color_slate-700)',
+            '--color': 'var(--color_slate-100)',
+          })}
+        >
+          Testing inherit
+        </div>
+      </div>
+
       <button
         style={css({
           '--border-block-end': 'var(---, 1px solid var(--color_slate-700))',

--- a/examples/remix/public/tokenami.css
+++ b/examples/remix/public/tokenami.css
@@ -18,6 +18,7 @@
     --radii_rounded: 10px;
     --font_sans: sans-serif;
     --color_slate-700: #334155;
+    --border_thin: 1px solid var(--color_slate-700);
     --anim_wiggle: wiggle 1s ease-in-out infinite;
     --radii_circle: 9999px;
     --size_auto: auto;

--- a/packages/dev/src/declarations.ts
+++ b/packages/dev/src/declarations.ts
@@ -39,8 +39,8 @@ type ThemeKey<P> = P extends keyof PropertyConfig
 type CSSPropertyValue<P> = P extends keyof CSS.PropertiesHyphen ? CSS.PropertiesHyphen[P] : never;
 
 type ThemePropertyValue<ThemeKey> = ThemeKey extends 'grid'
-  ? TokenVar<ThemeKey> | Tokenami.ArbitraryValue | Tokenami.GridValue | 'inherit'
-  : TokenVar<ThemeKey> | Tokenami.ArbitraryValue | 'inherit';
+  ? TokenVar<ThemeKey> | Tokenami.ArbitraryValue | Tokenami.GridValue | CSS.Globals
+  : TokenVar<ThemeKey> | Tokenami.ArbitraryValue | CSS.Globals;
 
 type PropertyValue<P> = ThemeKey<P> extends never
   ? CSSPropertyValue<P>

--- a/packages/dev/src/declarations.ts
+++ b/packages/dev/src/declarations.ts
@@ -39,8 +39,8 @@ type ThemeKey<P> = P extends keyof PropertyConfig
 type CSSPropertyValue<P> = P extends keyof CSS.PropertiesHyphen ? CSS.PropertiesHyphen[P] : never;
 
 type ThemePropertyValue<ThemeKey> = ThemeKey extends 'grid'
-  ? TokenVar<ThemeKey> | Tokenami.ArbitraryValue | Tokenami.GridValue
-  : TokenVar<ThemeKey> | Tokenami.ArbitraryValue;
+  ? TokenVar<ThemeKey> | Tokenami.ArbitraryValue | Tokenami.GridValue | 'inherit'
+  : TokenVar<ThemeKey> | Tokenami.ArbitraryValue | 'inherit';
 
 type PropertyValue<P> = ThemeKey<P> extends never
   ? CSSPropertyValue<P>


### PR DESCRIPTION
allows CSS globals for all properties (e.g. `inherit`, `unset` etc.) this makes things like this possible:

```tsx
<div style={css({ '--padding': 10 })}>
  boop
  <p style={css({ '--padding': 'inherit' })}>boop</p>
</div>
```

this will also lead to being able to do things like this when i complete #217

```tsx
<div style={css({ '--font-size': '20px' }})}>
  boop
  <svg 
    style={css({ 
      '--font-size': 'inherit', 
      '--width': 'var(--font-size)', 
      '--height': 'var(--font-size)' 
    })} 
  />
</div>
```