### PR TITLE
feat: support multiple themes

### DIFF
--- a/.changeset/mean-donkeys-buy.md
+++ b/.changeset/mean-donkeys-buy.md
@@ -1,0 +1,9 @@
+---
+'@tokenami/example-design-system': patch
+'@tokenami/ts-plugin': patch
+'@tokenami/config': patch
+'@tokenami/css': patch
+'@tokenami/dev': patch
+---
+
+Add support for multiple theme modes

--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ function Page() {
 
 ### Theming
 
-Tokenami relies on your theme to provide design system constraints. Since there's no predefined theme, you need to add your own to the `.tokenami/tokenami.config`. For example:
+Tokenami relies on your theme to provide design system constraints. There isn't a predefined theme so you must add your own to the `.tokenami/tokenami.config`. For example:
 
 ```ts
 module.exports = createConfig({
@@ -181,6 +181,40 @@ module.exports = createConfig({
 ```
 
 The keys in your `responsive` and `theme` objects can be anything you wish. These keys will be used to name your tokens (more on this later).
+
+Use the `modes` key to set up multiple themes if preferred:
+
+```ts
+module.exports = createConfig({
+  theme: {
+    modes: {
+      light: {
+        color: {
+          primary: '#f1f5f9',
+          secondary: '#334155',
+        },
+      },
+      dark: {
+        color: {
+          primary: '#0ea5e9',
+          secondary: '#f1f5f9',
+        },
+      },
+    },
+  },
+});
+```
+
+By default this will apply the CSS variables to `.theme-${mode}` classes that you must manually add to your page to apply the relevant theme. To customise this selector, there is a `tokenamiSelector` config option.
+
+```ts
+module.exports = createConfig({
+  themeSelector: (mode) => (mode === 'root' ? ':root' : `.theme-${mode}`),
+  theme: {
+    // ...
+  },
+});
+```
 
 ### Styling
 
@@ -369,7 +403,7 @@ function Button(props: ButtonProps) {
 
 ### Selectors
 
-Tokenami provides some [common default selectors](https://github.com/tokenami/tokenami/blob/main/packages/config/src/config.default.ts#L9) for you but you can define your own custom selectors in the `selectors` object of your config.
+Tokenami provides some [common default selectors](https://github.com/tokenami/tokenami/blob/main/packages/config/src/config.ts#L46) for you but you can define your own custom selectors in the `selectors` object of your config.
 
 Use the ampersand (`&`) to specify where the current element's selector should be injected:
 
@@ -459,7 +493,7 @@ With the above config, `px` is shorthand for `padding-left` and `padding-right`.
 
 Tokenami provides sensible defaults to restrict which values can be passed to properties based on your theme. For instance, `--border-color` will only accept tokens from your `color` object in theme, `--padding` allows multiples of your grid, and `--height` expects tokens from a `size` key or multiples of your grid.
 
-You can customise [the default configuration](https://github.com/tokenami/tokenami/blob/main/packages/config/src/config.default.ts#L68) by overriding the `properties` object:
+You can customise [the default configuration](https://github.com/tokenami/tokenami/blob/main/packages/config/src/config.ts#L61) by overriding the `properties` object:
 
 ```ts
 const { createConfig, defaultConfig } = require('@tokenami/css');
@@ -527,7 +561,7 @@ tsc --noEmit --project tsconfig.ci.json
 
 ### Design systems with Tokenami
 
-Integrating a design system built with Tokenami is straightforward. Simply include the `tokenami.config.js` file and corresponding stylesheet from the design system in your project as follows:
+Integrating a design system built with Tokenami is straightforward. Include the `tokenami.config.js` file and corresponding stylesheet from the design system in your project:
 
 ```tsx
 import { tokenamiConfig as designSystemConfig } from '@acme/design-system';
@@ -539,7 +573,7 @@ export default createConfig({
 });
 ```
 
-With these steps, Tokenami will automatically generate styles and merge them correctly across component boundaries. See the example [design system project](https://github.com/tokenami/tokenami/blob/main/examples/design-system) and [Remix project](https://github.com/tokenami/tokenami/blob/main/examples/remix/.tokenami/tokenami.config.ts) for a demo.
+Tokenami will automatically generate styles and merge them correctly across component boundaries. See the example [design system project](https://github.com/tokenami/tokenami/blob/main/examples/design-system) and [Remix project](https://github.com/tokenami/tokenami/blob/main/examples/remix/.tokenami/tokenami.config.ts) for a demo.
 
 ## Support
 

--- a/examples/design-system/.storylite/with-default-config.tsx
+++ b/examples/design-system/.storylite/with-default-config.tsx
@@ -1,4 +1,5 @@
 import type { SLFunctionComponent, Story } from '@storylite/storylite';
+import { useStoryLiteStore } from '@storylite/storylite';
 
 /* -------------------------------------------------------------------------------------------------
  * withDefaultConfig
@@ -10,8 +11,12 @@ function withDefaultConfig<T extends SLFunctionComponent>(story: Story<T>): Stor
     navigation: { hidden: true, ...story.navigation },
     decorators: [
       (Comp: any, context) => {
+        const params = useStoryLiteStore((state) => state.parameters);
         return (
-          <div style={{ padding: 20, borderRadius: '8px', background: '#ddd' }}>
+          <div
+            className={`theme-${params.theme?.value === 'auto' ? 'light' : params.theme?.value}`}
+            style={{ padding: 20, borderRadius: '8px', background: '#ddd' }}
+          >
             <Comp {...context?.args} />
           </div>
         );

--- a/examples/design-system/.tokenami/tokenami.config.ts
+++ b/examples/design-system/.tokenami/tokenami.config.ts
@@ -1,5 +1,40 @@
 import { createConfig, defaultConfig } from '@tokenami/css';
 
+const palette = {
+  'slate-100': '#f1f5f9',
+  'slate-700': '#334155',
+  'sky-500': '#0ea5e9',
+};
+
+const theme = {
+  color: {
+    ...palette,
+    primary: palette['slate-100'],
+    secondary: palette['slate-700'],
+    tertiary: palette['sky-500'],
+  },
+  anim: {
+    wiggle: 'wiggle 1s ease-in-out infinite',
+  },
+  border: {
+    thin: '1px solid var(--color_slate-700)',
+  },
+  font: {
+    serif: 'serif',
+    sans: 'sans-serif',
+  },
+  radii: {
+    rounded: '10px',
+    circle: '9999px',
+    none: 'none',
+  },
+  size: {
+    auto: 'auto',
+    fill: '100%',
+    'screen-h': '100vh',
+  },
+};
+
 export default createConfig({
   include: ['./src/**/*.{ts,tsx}'],
   responsive: {
@@ -9,34 +44,17 @@ export default createConfig({
     '2xl': '@media (min-width: 1536px)',
   },
   theme: {
-    anim: {
-      wiggle: 'wiggle 1s ease-in-out infinite',
-    },
-    color: {
-      'slate-100': '#f1f5f9',
-      'slate-700': '#334155',
-      'sky-500': '#0ea5e9',
-    },
-    border: {
-      thin: '1px solid var(--color_slate-700)',
-    },
-    font: {
-      serif: 'serif',
-      sans: 'sans-serif',
-    },
-    radii: {
-      rounded: '10px',
-      circle: '9999px',
-      none: 'none',
-    },
-    size: {
-      auto: 'auto',
-      fill: '100%',
-      'screen-h': '100vh',
-    },
-    pet: {
-      cat: '"🐱"',
-      dog: '"🐶"',
+    modes: {
+      light: theme,
+      dark: {
+        ...theme,
+        color: {
+          ...theme.color,
+          primary: palette['sky-500'],
+          secondary: palette['slate-100'],
+          tertiary: palette['slate-700'],
+        },
+      },
     },
   },
   keyframes: {

--- a/examples/design-system/package.json
+++ b/examples/design-system/package.json
@@ -13,11 +13,14 @@
   "scripts": {
     "build": "tsup && pnpm build:tokenami",
     "build:tokenami": "tokenami --output dist/tokenami.css --minify",
-    "dev": "pnpm dev:css & pnpm dev:storylite",
+    "dev": "concurrently \"pnpm:dev:*\"",
     "dev:storylite": "vite --port=7007 --host=0.0.0.0 --open",
     "dev:css": "tokenami --output ./src/tokenami.css --watch",
     "typecheck": "tsc --noEmit",
     "typecheck:ci": "pnpm typecheck"
+  },
+  "dependencies": {
+    "@tokenami/css": "workspace:*"
   },
   "devDependencies": {
     "@storylite/storylite": "^0.14.0",
@@ -25,6 +28,7 @@
     "@tokenami/dev": "workspace:*",
     "@tokenami/ts-plugin": "workspace:*",
     "@vitejs/plugin-react-swc": "^3.6.0",
+    "concurrently": "^8.2.0",
     "tsup": "^7.0.0",
     "typescript": "^5.1.3",
     "vite": "^5.1.6"
@@ -42,8 +46,5 @@
     "@types/react-dom": {
       "optional": true
     }
-  },
-  "dependencies": {
-    "@tokenami/css": "workspace:*"
   }
 }

--- a/examples/design-system/src/button/button.tsx
+++ b/examples/design-system/src/button/button.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { type Variants, type TokenamiStyle, css } from '@tokenami/css';
+import { type Variants, type TokenamiStyle, css } from '~/css';
 
 /* -------------------------------------------------------------------------------------------------
  * Button
@@ -18,7 +18,8 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>((props, forwarde
 });
 
 const button = css.compose({
-  '--bg-color': 'var(--color_slate-100)',
+  '--bg-color': 'var(--color_primary)',
+  '--color': 'var(--color_secondary)',
   '--border': 'var(---,none)',
   '--border-bottom': 'var(---, 2px solid var(--color_slate-700))',
   '--border-radius': 'var(--radii_rounded)',

--- a/examples/design-system/src/css.ts
+++ b/examples/design-system/src/css.ts
@@ -1,0 +1,5 @@
+import { createCss } from '@tokenami/css';
+import config from '../.tokenami/tokenami.config';
+
+export type * from '@tokenami/css';
+export const css = createCss(config);

--- a/examples/design-system/src/tokenami.css
+++ b/examples/design-system/src/tokenami.css
@@ -9,13 +9,24 @@
     }
   }
 
-  :root {
+  .theme-light {
     --_grid: .25rem;
-    --color_slate-100: #f1f5f9;
-    --color_slate-700: #334155;
-    --radii_rounded: 10px;
-    --font_sans: sans-serif;
     --anim_wiggle: wiggle 1s ease-in-out infinite;
+    --color_primary: #f1f5f9;
+    --color_secondary: #334155;
+    --color_slate-700: #334155;
+    --font_sans: sans-serif;
+    --radii_rounded: 10px;
+  }
+
+  .theme-dark {
+    --_grid: .25rem;
+    --anim_wiggle: wiggle 1s ease-in-out infinite;
+    --color_primary: #0ea5e9;
+    --color_secondary: #f1f5f9;
+    --color_slate-700: #334155;
+    --font_sans: sans-serif;
+    --radii_rounded: 10px;
   }
 
   [style] {
@@ -26,6 +37,7 @@
     --border-radius: initial;
     --_853it7: var(--hover) var(--hover_color);
     --hover_color: initial;
+    --color: initial;
     --height: initial;
     --transition: initial;
     --width: initial;
@@ -53,6 +65,7 @@
     [style] {
       border: var(--border, revert-layer);
       border-radius: var(--border-radius, revert-layer);
+      color: var(--color, revert-layer);
       height: var(--height, revert-layer);
       transition: var(--transition, revert-layer);
       width: var(--width, revert-layer);

--- a/examples/design-system/vite.config.ts
+++ b/examples/design-system/vite.config.ts
@@ -19,4 +19,9 @@ export default defineConfig({
     }),
     react(),
   ],
+  resolve: {
+    alias: {
+      '~': resolve(__dirname, 'src'),
+    },
+  },
 });

--- a/examples/remix/.tokenami/tokenami.config.ts
+++ b/examples/remix/.tokenami/tokenami.config.ts
@@ -3,20 +3,9 @@ import { createConfig } from '@tokenami/css';
 
 export default createConfig({
   ...designSystemConfig,
+  exclude: ['./app/routes/original.tsx', './app/test.tsx'],
   include: [
     './app/**/*.{ts,tsx}',
-    'node_modules/@tokenami/example-design-system/dist/tokenami.css',
+    './node_modules/@tokenami/example-design-system/dist/tokenami.css',
   ],
-  exclude: ['./app/routes/original.tsx', './app/test.tsx'],
-  theme: {
-    ...designSystemConfig.theme,
-    pet: {
-      cat: '"🐱"',
-      dog: '"🐶"',
-    },
-  },
-  properties: {
-    ...designSystemConfig.properties,
-    content: ['pet'],
-  },
 });

--- a/examples/remix/app/root.tsx
+++ b/examples/remix/app/root.tsx
@@ -10,7 +10,10 @@ export default function App() {
         <Meta />
         <Links />
       </head>
-      <body style={css({ '--min-height': 'var(--size_fill)', '--m': 0, '--p': 0 })}>
+      <body
+        className={'theme-light'}
+        style={css({ '--min-height': 'var(--size_fill)', '--m': 0, '--p': 0 })}
+      >
         <Outlet />
         <ScrollRestoration />
         <Scripts />

--- a/examples/remix/public/tokenami.css
+++ b/examples/remix/public/tokenami.css
@@ -9,20 +9,40 @@
     }
   }
 
-  :root {
+  .theme-light {
     --_grid: .25rem;
+    --anim_wiggle: wiggle 1s ease-in-out infinite;
+    --border_thin: 1px solid var(--color_slate-700);
+    --color_primary: #f1f5f9;
+    --color_secondary: #334155;
+    --color_sky-500: #0ea5e9;
     --color_slate-100: #f1f5f9;
     --color_slate-700: #334155;
-    --radii_rounded: 10px;
     --font_sans: sans-serif;
-    --anim_wiggle: wiggle 1s ease-in-out infinite;
-    --size_fill: 100%;
-    --color_sky-500: #0ea5e9;
-    --size_screen-h: 100vh;
-    --border_thin: 1px solid var(--color_slate-700);
     --radii_circle: 9999px;
-    --size_auto: auto;
     --radii_none: none;
+    --radii_rounded: 10px;
+    --size_auto: auto;
+    --size_fill: 100%;
+    --size_screen-h: 100vh;
+  }
+
+  .theme-dark {
+    --_grid: .25rem;
+    --anim_wiggle: wiggle 1s ease-in-out infinite;
+    --border_thin: 1px solid var(--color_slate-700);
+    --color_primary: #0ea5e9;
+    --color_secondary: #f1f5f9;
+    --color_sky-500: #0ea5e9;
+    --color_slate-100: #f1f5f9;
+    --color_slate-700: #334155;
+    --font_sans: sans-serif;
+    --radii_circle: 9999px;
+    --radii_none: none;
+    --radii_rounded: 10px;
+    --size_auto: auto;
+    --size_fill: 100%;
+    --size_screen-h: 100vh;
   }
 
   [style] {

--- a/packages/config/src/common.ts
+++ b/packages/config/src/common.ts
@@ -53,7 +53,7 @@ const VariantProperty = {
   safeParse: (input: unknown) => validate<VariantProperty>(variantPropertyRegex, input),
 };
 
-function variantProperty(variant: string, name: string): TokenProperty {
+function variantProperty(variant: string, name: string): VariantProperty {
   return `--${variant}_${name}`;
 }
 

--- a/packages/css/src/css.ts
+++ b/packages/css/src/css.ts
@@ -172,5 +172,5 @@ function convertToMediaStyles(bp: string, styles: TokenamiProperties): TokenamiP
 
 /* ---------------------------------------------------------------------------------------------- */
 
-export type { TokenamiCSS };
+export type { TokenamiCSS, CSS };
 export { createCss, css, convertToMediaStyles };

--- a/packages/css/src/index.ts
+++ b/packages/css/src/index.ts
@@ -1,6 +1,4 @@
 import type { TokenamiCSS } from './css';
-export { createConfig, defaultConfig } from '@tokenami/config';
-export { createCss, css } from './css';
 
 export type TokenamiStyle<P> = {
   [K in keyof P]: K extends 'style' ? TokenamiCSS & P[K] : P[K];
@@ -9,3 +7,7 @@ export type TokenamiStyle<P> = {
 export type Variants<T extends () => {}> = Parameters<T>[0] extends undefined | null
   ? {}
   : NonNullable<Parameters<T>[0]>;
+
+export type { TokenamiCSS, CSS } from './css';
+export { createConfig, defaultConfig } from '@tokenami/config';
+export { createCss, css } from './css';

--- a/packages/dev/src/cli.ts
+++ b/packages/dev/src/cli.ts
@@ -206,8 +206,8 @@ function matchTokens(content: string, theme: Tokenami.Config['theme']) {
   const values = variableMatches.flatMap((match) => {
     const valueProperty = Tokenami.TokenValue.safeParse(`var(${match})`);
     if (!valueProperty.success) return [];
-    const themeValues = utils.getThemeValuesForTokenValue(valueProperty.output, theme);
-    return themeValues.length ? [valueProperty.output] : [];
+    const themeValues = utils.getThemeValuesByThemeMode(valueProperty.output, theme);
+    return Object.entries(themeValues).length ? [valueProperty.output] : [];
   });
 
   const properties = variableMatches.flatMap((match) => {

--- a/packages/dev/src/cli.ts
+++ b/packages/dev/src/cli.ts
@@ -206,9 +206,8 @@ function matchTokens(content: string, theme: Tokenami.Config['theme']) {
   const values = variableMatches.flatMap((match) => {
     const valueProperty = Tokenami.TokenValue.safeParse(`var(${match})`);
     if (!valueProperty.success) return [];
-    const parts = Tokenami.getTokenValueParts(valueProperty.output);
-    const value = theme[parts.themeKey]?.[parts.token];
-    return value == null ? [] : [valueProperty.output];
+    const themeValues = utils.getThemeValuesForTokenValue(valueProperty.output, theme);
+    return themeValues.length ? [valueProperty.output] : [];
   });
 
   const properties = variableMatches.flatMap((match) => {

--- a/packages/dev/src/declarations.ts
+++ b/packages/dev/src/declarations.ts
@@ -11,6 +11,7 @@ type DefaultConfig = Tokenami.DefaultConfig & { CI: false };
 interface TokenamiFinalConfig extends Merge<DefaultConfig, TokenamiConfig> {}
 
 type ThemeConfig = TokenamiFinalConfig['theme'];
+type Theme = ThemeConfig extends Tokenami.ThemeModes<infer T> ? T : ThemeConfig;
 type PropertyConfig = TokenamiFinalConfig['properties'];
 type SelectorKey = ExtractKeys<TokenamiFinalConfig['selectors']>;
 type ResponsiveKey = ExtractKeys<TokenamiFinalConfig['responsive']>;
@@ -22,7 +23,7 @@ type ResponsiveSelectorKey = ResponsiveKey extends never
   ? never
   : `${ResponsiveKey}_${SelectorKey}`;
 
-type TokenName<ThemeKey> = ThemeKey extends keyof ThemeConfig ? keyof ThemeConfig[ThemeKey] : never;
+type TokenName<ThemeKey> = ThemeKey extends keyof Theme ? keyof Theme[ThemeKey] : never;
 
 type TokenVar<ThemeKey> = ThemeKey extends string
   ? TokenName<ThemeKey> extends `${infer Token}`

--- a/packages/dev/src/sheet.ts
+++ b/packages/dev/src/sheet.ts
@@ -152,7 +152,7 @@ function getAtomicLayer(cssProperty: string) {
 
 function generateKeyframeRules(tokenValues: Tokenami.TokenValue[], config: Tokenami.Config) {
   const themeValues = tokenValues.flatMap((tokenValue) => {
-    return utils.getThemeValuesForTokenValue(tokenValue, config.theme);
+    return Object.values(utils.getThemeValuesByThemeMode(tokenValue, config.theme));
   });
   return Object.entries(config.keyframes || {}).flatMap(([name, styles]) => {
     const nameRegex = new RegExp(`\\b${name}\\b`);
@@ -175,10 +175,7 @@ function generateThemeTokens(tokenValues: Tokenami.TokenValue[], config: Tokenam
     const modeThemeEntries = Object.entries(modes).map(([mode, theme]) => {
       const modeThemeSelector = config.themeSelector ? config.themeSelector(mode) : rootSelector;
       const modeThemeValues = utils.getThemeValuesByTokenValues(tokenValues, theme);
-      return [
-        mode === 'root' ? rootSelector : modeThemeSelector,
-        { ...gridValue, ...modeThemeValues },
-      ];
+      return [modeThemeSelector, { ...gridValue, ...modeThemeValues }];
     });
 
     return stringify(Object.fromEntries(modeThemeEntries));

--- a/packages/dev/src/sheet.ts
+++ b/packages/dev/src/sheet.ts
@@ -83,9 +83,9 @@ function generate(params: {
   const sheet = `
     @layer tokenami {
       ${generateKeyframeRules(tokenValues, params.config)}
-      :root { ${generateRootStyles(tokenValues, params.config)} }
-      [style] { ${Array.from(styles.reset).join(' ')} }
+      ${generateThemeTokens(tokenValues, params.config)}
 
+      [style] { ${Array.from(styles.reset).join(' ')} }
       @layer ${Tokenami.layers.map((_, layer) => `tk-${layer}`).join(', ')};
       @layer ${Tokenami.layers.map((_, layer) => `tk-selector-${layer}`).join(', ')};
 
@@ -152,9 +152,7 @@ function getAtomicLayer(cssProperty: string) {
 
 function generateKeyframeRules(tokenValues: Tokenami.TokenValue[], config: Tokenami.Config) {
   const themeValues = tokenValues.flatMap((tokenValue) => {
-    const parts = Tokenami.getTokenValueParts(tokenValue);
-    const value = config.theme[parts.themeKey]?.[parts.token];
-    return value == null ? [] : [value];
+    return utils.getThemeValuesForTokenValue(tokenValue, config.theme);
   });
   return Object.entries(config.keyframes || {}).flatMap(([name, styles]) => {
     const nameRegex = new RegExp(`\\b${name}\\b`);
@@ -165,14 +163,29 @@ function generateKeyframeRules(tokenValues: Tokenami.TokenValue[], config: Token
 }
 
 /* -------------------------------------------------------------------------------------------------
- * generateRootStyles
+ * generateThemeTokens
  * -----------------------------------------------------------------------------------------------*/
 
-function generateRootStyles(tokenValues: Tokenami.TokenValue[], config: Tokenami.Config) {
-  return stringify({
-    [Tokenami.gridProperty()]: config.grid,
-    ...utils.getThemeValuesByTokenValues(tokenValues, config.theme),
-  });
+function generateThemeTokens(tokenValues: Tokenami.TokenValue[], config: Tokenami.Config) {
+  const { modes, ...rootTheme } = config.theme;
+  const gridValue = { [Tokenami.gridProperty()]: config.grid };
+  const rootSelector = ':root';
+
+  if (modes) {
+    const modeThemeEntries = Object.entries(modes).map(([mode, theme]) => {
+      const modeThemeSelector = config.themeSelector ? config.themeSelector(mode) : rootSelector;
+      const modeThemeValues = utils.getThemeValuesByTokenValues(tokenValues, theme);
+      return [
+        mode === 'root' ? rootSelector : modeThemeSelector,
+        { ...gridValue, ...modeThemeValues },
+      ];
+    });
+
+    return stringify(Object.fromEntries(modeThemeEntries));
+  }
+
+  const rootThemeValues = utils.getThemeValuesByTokenValues(tokenValues, rootTheme);
+  return stringify({ [rootSelector]: { ...gridValue, ...rootThemeValues } });
 }
 
 /* -------------------------------------------------------------------------------------------------

--- a/packages/dev/src/utils/common.ts
+++ b/packages/dev/src/utils/common.ts
@@ -89,17 +89,33 @@ function getCiTypeDefsPath(configPath: string) {
  * getThemeValuesByTokenValues
  * -----------------------------------------------------------------------------------------------*/
 
-function getThemeValuesByTokenValues(used: Tokenami.TokenValue[], theme: Tokenami.Theme) {
-  const themeKeys = Object.keys(theme);
-  const entries = used.flatMap((tokenValue) => {
+function getThemeValuesByTokenValues(tokenValues: Tokenami.TokenValue[], theme: Tokenami.Theme) {
+  // make entries a deterministic order instead of usage order
+  const sorted = [...tokenValues].sort();
+  const entries = sorted.flatMap((tokenValue) => {
     const parts = Tokenami.getTokenValueParts(tokenValue);
     const value = theme[parts.themeKey]?.[parts.token];
     if (value == null) return [];
     return [[parts.property, value]] as const;
   });
-  // make rules a deterministic order (theme key order) instead of usage order
-  const sorted = entries.sort((a, b) => themeKeys.indexOf(a[0]) - themeKeys.indexOf(b[0]));
-  return Object.fromEntries(sorted);
+  return Object.fromEntries(entries);
+}
+
+/* -------------------------------------------------------------------------------------------------
+ * getThemeValuesForTokenValue
+ * -----------------------------------------------------------------------------------------------*/
+
+function getThemeValuesForTokenValue(
+  tokenValue: Tokenami.TokenValue,
+  themeConfig: Tokenami.Config['theme']
+): string[] {
+  const { modes = {}, ...rootTheme } = themeConfig;
+  const parts = Tokenami.getTokenValueParts(tokenValue);
+  const modeThemes: Tokenami.Theme[] = Object.values(modes);
+  return modeThemes.concat(rootTheme).flatMap((theme) => {
+    const value = theme[parts.themeKey]?.[parts.token];
+    return value ? [value] : [];
+  });
 }
 
 /* -------------------------------------------------------------------------------------------------
@@ -155,7 +171,7 @@ function getSpecifictyOrderForCSSProperty(cssProperty: Tokenami.CSSProperty) {
 function getResponsivePropertyVariants(
   tokenProperty: Tokenami.TokenProperty,
   responsive: Tokenami.Config['responsive']
-) {
+): Tokenami.VariantProperty[] {
   return Object.keys(responsive || {}).map((query) => {
     const name = Tokenami.getTokenPropertyName(tokenProperty);
     return Tokenami.variantProperty(query, name);
@@ -192,6 +208,7 @@ export {
   generateTypeDefs,
   generateCiTypeDefs,
   getThemeValuesByTokenValues,
+  getThemeValuesForTokenValue,
   getResponsivePropertyVariants,
   getSpecifictyOrderForCSSProperty,
   unique,

--- a/packages/dev/src/utils/common.ts
+++ b/packages/dev/src/utils/common.ts
@@ -102,20 +102,24 @@ function getThemeValuesByTokenValues(tokenValues: Tokenami.TokenValue[], theme: 
 }
 
 /* -------------------------------------------------------------------------------------------------
- * getThemeValuesForTokenValue
+ * getThemeValuesByThemeMode
  * -----------------------------------------------------------------------------------------------*/
 
-function getThemeValuesForTokenValue(
+type Mode = string & {};
+type ThemeValue = string & {};
+
+function getThemeValuesByThemeMode(
   tokenValue: Tokenami.TokenValue,
   themeConfig: Tokenami.Config['theme']
-): string[] {
+): Record<Mode, ThemeValue> {
   const { modes = {}, ...rootTheme } = themeConfig;
   const parts = Tokenami.getTokenValueParts(tokenValue);
-  const modeThemes: Tokenami.Theme[] = Object.values(modes);
-  return modeThemes.concat(rootTheme).flatMap((theme) => {
+  const modeThemeEntries: [string, Tokenami.Theme][] = Object.entries(modes);
+  const modeValues = modeThemeEntries.concat([['root', rootTheme]]).flatMap(([mode, theme]) => {
     const value = theme[parts.themeKey]?.[parts.token];
-    return value ? [value] : [];
+    return value ? [[mode, value] as const] : [];
   });
+  return Object.fromEntries(modeValues);
 }
 
 /* -------------------------------------------------------------------------------------------------
@@ -208,7 +212,7 @@ export {
   generateTypeDefs,
   generateCiTypeDefs,
   getThemeValuesByTokenValues,
-  getThemeValuesForTokenValue,
+  getThemeValuesByThemeMode,
   getResponsivePropertyVariants,
   getSpecifictyOrderForCSSProperty,
   unique,

--- a/packages/ts-plugin/src/index.ts
+++ b/packages/ts-plugin/src/index.ts
@@ -277,7 +277,7 @@ function init(modules: { typescript: typeof tslib }) {
 
           if (property.success) {
             const parts = TokenamiConfig.getTokenValueParts(property.output);
-            const value = config.theme[parts.themeKey]?.[parts.token];
+            const [value] = Tokenami.getThemeValuesForTokenValue(property.output, config.theme);
 
             if (value !== undefined) {
               const name = `$${parts.token}`;

--- a/packages/ts-plugin/src/index.ts
+++ b/packages/ts-plugin/src/index.ts
@@ -400,19 +400,21 @@ function init(modules: { typescript: typeof tslib }) {
 /* ---------------------------------------------------------------------------------------------- */
 
 function createColorTokenDescription(modeValues: NonNullable<EntryConfigItem['modeValues']>) {
-  const entries = Object.entries(modeValues);
-  const [, firstValue] = entries[0] || [];
-  const rows = Object.entries(modeValues).map(([mode, value]) => {
-    return createRow([createSquare(value), mode, value]);
-  });
-  return `${firstValue}\n\n${rows.join(`\n\n`)}`;
+  return createDescription(modeValues, (mode, value) => [createSquare(value), mode, value]);
 }
 
 function createTokenDescription(modeValues: NonNullable<EntryConfigItem['modeValues']>) {
+  return createDescription(modeValues, (mode, value) => [mode, value]);
+}
+
+function createDescription(
+  modeValues: NonNullable<EntryConfigItem['modeValues']>,
+  builder: (mode: string, value: string) => string[]
+) {
   const entries = Object.entries(modeValues);
   const [, firstValue] = entries[0] || [];
-  const rows = Object.entries(modeValues).flatMap(([mode, value]) => {
-    return value !== firstValue ? [createRow([mode, value])] : [];
+  const rows = entries.flatMap(([mode, value]) => {
+    return value !== firstValue ? [createRow(builder(mode, value))] : [];
   });
   return `${firstValue}\n\n${rows.join(`\n\n`)}`;
 }

--- a/packages/ts-plugin/src/index.ts
+++ b/packages/ts-plugin/src/index.ts
@@ -274,6 +274,7 @@ function init(modules: { typescript: typeof tslib }) {
         original.entries = original.entries.map((entry) => {
           const entryName = entry.name;
           const property = TokenamiConfig.TokenValue.safeParse(entryName);
+          entry.sortText = entryName;
 
           if (property.success) {
             const parts = TokenamiConfig.getTokenValueParts(property.output);
@@ -283,7 +284,7 @@ function init(modules: { typescript: typeof tslib }) {
               const name = `$${parts.token}`;
               const kindModifiers = parts.themeKey;
               entry.name = name;
-              entry.sortText = entryName;
+              entry.sortText = '$' + entryName;
               entry.kindModifiers = kindModifiers;
               entry.insertText = entryName;
               entry.labelDetails = { detail: '', description: entryName };
@@ -296,9 +297,10 @@ function init(modules: { typescript: typeof tslib }) {
       } else if (isTokenPropertyEntries) {
         original.entries = original.entries.flatMap((entry) => {
           const property = TokenamiConfig.TokenProperty.safeParse(entry.name);
+          entry.sortText = entry.name;
           // filter any suggestions that aren't tokenami properties (e.g. backgroundColor)
           if (!property.success) return [];
-          entry.sortText = property.output;
+          entry.sortText = '$' + property.output;
           entry.insertText = property.output;
           return [entry];
         });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -54,6 +54,9 @@ importers:
       '@vitejs/plugin-react-swc':
         specifier: ^3.6.0
         version: 3.6.0(vite@5.1.6)
+      concurrently:
+        specifier: ^8.2.0
+        version: 8.2.2
       tsup:
         specifier: ^7.0.0
         version: 7.3.0(typescript@5.3.3)


### PR DESCRIPTION
closes #81 

adds a new optional `modes` key to `theme`, when used you can define different light/dark/etc. modes and styles will be applied to whichever selector you define via the new `themeSelector` option. it will declare vars in a `.theme-${mode}` class by default. if the mode is named `root` it will declare them in `:root`.