### PR TITLE
feat: add a simple lru cache to css util

### DIFF
--- a/.changeset/shiny-kids-rest.md
+++ b/.changeset/shiny-kids-rest.md
@@ -1,0 +1,9 @@
+---
+'@tokenami/css': patch
+'@tokenami/example-design-system': patch
+'@tokenami/config': patch
+'@tokenami/dev': patch
+'@tokenami/ts-plugin': patch
+---
+
+Add simple LRU cache to css utility


### PR DESCRIPTION
the previous implementation was hurried and cld potentially result in a memory leak as an application grows. this implements a simple LRU cache to evict entries that haven't been used recently.