### PR TITLE
fix: prevent keyframes error with multiple keyframe definitions

### DIFF
--- a/.changeset/silent-houses-relax.md
+++ b/.changeset/silent-houses-relax.md
@@ -1,0 +1,9 @@
+---
+'@tokenami/dev': patch
+'@tokenami/example-design-system': patch
+'@tokenami/config': patch
+'@tokenami/css': patch
+'@tokenami/ts-plugin': patch
+---
+
+Prevent keyframes error when supplying multiple keyframes

--- a/packages/dev/src/sheet.ts
+++ b/packages/dev/src/sheet.ts
@@ -171,12 +171,15 @@ function generateKeyframeRules(tokenValues: Tokenami.TokenValue[], config: Token
   const themeValues = tokenValues.flatMap((tokenValue) => {
     return Object.values(utils.getThemeValuesByThemeMode(tokenValue, config.theme));
   });
-  return Object.entries(config.keyframes || {}).flatMap(([name, styles]) => {
+
+  const rules = Object.entries(config.keyframes || {}).flatMap(([name, styles]) => {
     const nameRegex = new RegExp(`\\b${name}\\b`);
     const isUsingKeyframeName = themeValues.some((value) => nameRegex.test(value));
     if (!isUsingKeyframeName) return [];
     return [[`@keyframes ${name} { ${stringify(styles)} }`]];
   });
+
+  return rules.join(' ');
 }
 
 /* -------------------------------------------------------------------------------------------------


### PR DESCRIPTION
Closes #235

It was stringifying the array of keyframes which added a comma after each keyframe definition and lightningcss couldn't parse that. this joins the string of keyframes w/o comma.