### PR TITLE
Add support for text-wrap CSS property

### DIFF
--- a/.changeset/slow-humans-act.md
+++ b/.changeset/slow-humans-act.md
@@ -1,0 +1,6 @@
+---
+'@tokenami/config': patch
+'@tokenami/dev': patch
+---
+
+Add support for text-wrap CSS property

--- a/packages/config/src/supports.ts
+++ b/packages/config/src/supports.ts
@@ -152,6 +152,7 @@ const layers = [
     'text-transform',
     'text-underline-offset',
     'text-underline-position',
+    'text-wrap',
     'touch-action',
     'transform',
     'transform-box',

--- a/packages/dev/src/declarations.ts
+++ b/packages/dev/src/declarations.ts
@@ -453,6 +453,7 @@ type Properties = Property['-webkit-line-clamp'] &
   Property['text-transform'] &
   Property['text-underline-offset'] &
   Property['text-underline-position'] &
+  Property['text-wrap'] &
   Property['touch-action'] &
   Property['transform'] &
   Property['transform-box'] &


### PR DESCRIPTION
[Looks like `text-wrap` is a shorthand for `text-wrap-mode` and `text-wrap-style`](https://developer.mozilla.org/en-US/docs/Web/CSS/text-wrap#constituent_properties), so I _think_ I've put it in the right layer.
I tried to add the longhand properties as well, but `csstype` didn't have types for them so would have to patch the package or mess with the types so opted to leave them out.