### PR TITLE
Revert "feat: remove ci types workaround"

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -23,7 +23,7 @@ jobs:
         run: pnpm build
 
       - name: 🔍 Typecheck
-        run: pnpm typecheck
+        run: pnpm typecheck:ci
 
       - name: 🔍 Test
         run: pnpm test

--- a/README.md
+++ b/README.md
@@ -88,8 +88,9 @@ https://github.com/tokenami/tokenami/assets/175330/123e5386-75af-4dbe-8d0c-1015e
   - [Selectors](#user-content-selectors)
   - [Aliases](#user-content-aliases)
   - [Mapping properties to theme](#user-content-mapping-properties-to-theme)
-  - [Design systems with Tokenami](#user-content-design-systems-with-tokenami)
   - [Browserslist](#user-content-browserslist)
+  - [Continuous Integration](#user-content-continuous-integration)
+  - [Design systems with Tokenami](#user-content-design-systems-with-tokenami)
 - [Support](#user-content-support)
   - [Supported frameworks](#user-content-supported-frameworks)
   - [Supported browsers](#user-content-supported-browsers)
@@ -122,7 +123,7 @@ Add Tokenami to `include` and `plugins` in your `tsconfig.json` or `jsconfig.jso
 
 ```json
 {
-  "include": [".tokenami/tokenami.env.d.ts"],
+  "include": [".tokenami/tokenami.env.d.ts", "**/*.ts", "**/*.tsx"],
   "compilerOptions": {
     "plugins": [{ "name": "@tokenami/ts-plugin" }]
   }
@@ -538,6 +539,36 @@ With this configuration, using `'--content': 'var(--container_half)'` would erro
 />
 ```
 
+### Browserslist
+
+Tokenami only supports [browserslist](https://browsersl.ist/) in your `package.json`. You can use it to add autoprefixing to your CSS properties in the generated CSS file. However, it currently doesn't support vendor-prefixed **values**, which is being tracked in [this issue](https://github.com/tokenami/tokenami/issues/103).
+
+> [!Note]
+> Tokenami does not support browsers below the listed [supported browser versions](#user-content-supported-browsers).
+
+### Continuous Integration
+
+To improve performance during development, Tokenami widens its types and uses the TypeScript plugin for completions. Using `tsc` in the command line defaults to these widened types so it will not highlight errors for your properties or tokens. To get accurate types for CI, do the following:
+
+#### Create a CI project config
+
+Create a file named `tsconfig.ci.json` or `jsconfig.ci.json`. It should extend your original config and include the CI-specific Tokenami types:
+
+```json
+{
+  "extends": "./tsconfig.json",
+  "include": [".tokenami/tokenami.env.ci.d.ts", "**/*.ts", "**/*.tsx"]
+}
+```
+
+#### Reference CI project config
+
+For CI, use `tsc` with your new configuration:
+
+```sh
+tsc --noEmit --project tsconfig.ci.json
+```
+
 ### Design systems with Tokenami
 
 Integrating a design system built with Tokenami is straightforward. Include the `tokenami.config.js` file and corresponding stylesheet from the design system in your project:
@@ -553,13 +584,6 @@ export default createConfig({
 ```
 
 Tokenami will automatically generate styles and merge them correctly across component boundaries. See the example [design system project](https://github.com/tokenami/tokenami/blob/main/examples/design-system) and [Remix project](https://github.com/tokenami/tokenami/blob/main/examples/remix/.tokenami/tokenami.config.ts) for a demo.
-
-### Browserslist
-
-Tokenami only supports [browserslist](https://browsersl.ist/) in your `package.json`. You can use it to add autoprefixing to your CSS properties in the generated CSS file. However, it currently doesn't support vendor-prefixed **values**, which is being tracked in [this issue](https://github.com/tokenami/tokenami/issues/103).
-
-> [!Note]
-> Tokenami does not support browsers below the listed [supported browser versions](#user-content-supported-browsers).
 
 ## Support
 

--- a/examples/design-system/.tokenami/tokenami.env.ci.d.ts
+++ b/examples/design-system/.tokenami/tokenami.env.ci.d.ts
@@ -1,0 +1,8 @@
+/// <reference types="./tokenami.env.d.ts" />
+import type { Config } from './tokenami.env';
+
+declare module '@tokenami/dev' {
+  interface TokenamiConfig extends Config {
+    CI: true;
+  }
+}

--- a/examples/design-system/package.json
+++ b/examples/design-system/package.json
@@ -16,7 +16,8 @@
     "dev": "concurrently \"pnpm:dev:*\"",
     "dev:storylite": "vite --port=7007 --host=0.0.0.0 --open",
     "dev:css": "tokenami --output ./src/tokenami.css --watch",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "typecheck:ci": "pnpm typecheck"
   },
   "dependencies": {
     "@tokenami/css": "workspace:*"

--- a/examples/remix/.tokenami/tokenami.env.ci.d.ts
+++ b/examples/remix/.tokenami/tokenami.env.ci.d.ts
@@ -1,0 +1,8 @@
+/// <reference types="./tokenami.env.d.ts" />
+import type { Config } from './tokenami.env';
+
+declare module '@tokenami/dev' {
+  interface TokenamiConfig extends Config {
+    CI: true;
+  }
+}

--- a/examples/remix/package.json
+++ b/examples/remix/package.json
@@ -12,6 +12,7 @@
     "dev:css": "pnpm build:css --watch",
     "start": "remix-serve build",
     "typecheck": "tsc --noEmit",
+    "typecheck:ci": "tsc --noEmit --project tsconfig.ci.json",
     "lint": "eslint ."
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "build": "pnpm -r --filter=./packages/** build && pnpm -r --filter=./examples/design-system build",
     "clean": "rm -rf **/node_modules && rm -rf **/dist",
     "typecheck": "pnpm -r --parallel typecheck",
+    "typecheck:ci": "pnpm -r --parallel typecheck:ci",
     "test": "pnpm -r --parallel test",
     "change": "changeset",
     "next:version": "changeset pre enter next || : && changeset version",

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -12,7 +12,8 @@
   ],
   "scripts": {
     "build": "tsup src/index.ts --format=esm,cjs --dts",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "typecheck:ci": "pnpm typecheck"
   },
   "devDependencies": {
     "@tokenami/dev": "workspace:*",

--- a/packages/css/package.json
+++ b/packages/css/package.json
@@ -15,6 +15,7 @@
     "build": "tsup",
     "dev": "pnpm build --watch src",
     "typecheck": "tsc --noEmit",
+    "typecheck:ci": "pnpm typecheck",
     "test": "vitest --run",
     "test:watch": "vitest"
   },

--- a/packages/dev/package.json
+++ b/packages/dev/package.json
@@ -18,7 +18,8 @@
   "scripts": {
     "build": "tsup",
     "dev": "pnpm build --watch src",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "typecheck:ci": "pnpm typecheck"
   },
   "devDependencies": {
     "@types/inquirer": "^9.0.7",

--- a/packages/dev/src/cli.ts
+++ b/packages/dev/src/cli.ts
@@ -58,11 +58,13 @@ const run = () => {
       const configPath = utils.getConfigPath(cwd, flags?.config, type);
       const outDir = pathe.dirname(configPath);
       const initialConfig = utils.generateConfig(include, configPath);
+      const ciTypeDefs = utils.generateCiTypeDefs(configPath);
       const typeDefs = utils.generateTypeDefs(configPath);
 
       fs.mkdirSync(outDir, { recursive: true });
       fs.writeFileSync(configPath, initialConfig, { flag: 'w' });
       fs.writeFileSync(utils.getTypeDefsPath(configPath), typeDefs, { flag: 'w' });
+      fs.writeFileSync(utils.getCiTypeDefsPath(configPath), ciTypeDefs, { flag: 'w' });
       log.debug(`Project successfully configured in './tokenami'`);
     });
 

--- a/packages/dev/src/declarations.ts
+++ b/packages/dev/src/declarations.ts
@@ -1,11 +1,13 @@
 import type * as CSS from 'csstype';
 import type * as Tokenami from '@tokenami/config';
 
-type Merge<A, B> = B extends never ? A : Omit<A, keyof B> & B;
-
 // consumer will override this interface
 interface TokenamiConfig {}
-interface TokenamiFinalConfig extends Merge<Tokenami.DefaultConfig, TokenamiConfig> {}
+
+type Merge<A, B> = B extends never ? A : Omit<A, keyof B> & B;
+
+type DefaultConfig = Tokenami.DefaultConfig & { CI: false };
+interface TokenamiFinalConfig extends Merge<DefaultConfig, TokenamiConfig> {}
 
 type ThemeConfig = TokenamiFinalConfig['theme'];
 type AliasConfig = TokenamiFinalConfig['aliases'];
@@ -34,7 +36,9 @@ type PropertyThemeValue<ThemeKey> = ThemeKey extends 'grid' | keyof TokensByThem
 
 type VariantProperty<P extends string> =
   | Tokenami.TokenProperty<P>
-  | Tokenami.VariantProperty<P, ResponsiveKey | SelectorKey | ResponsiveSelectorKey>;
+  | (TokenamiFinalConfig['CI'] extends true
+      ? Tokenami.VariantProperty<P, ResponsiveKey | SelectorKey | ResponsiveSelectorKey>
+      : Tokenami.VariantProperty<P, string>);
 
 type AliasedProperty<P> = {
   [A in keyof AliasConfig]: P extends AliasConfig[A][number] ? VariantProperty<A> : never;

--- a/packages/dev/src/utils/common.ts
+++ b/packages/dev/src/utils/common.ts
@@ -153,6 +153,14 @@ function generateTypeDefs(configPath: string, stubPath = '../stubs/tokenami.env.
 }
 
 /* -------------------------------------------------------------------------------------------------
+ * generateCiTypeDefs
+ * -----------------------------------------------------------------------------------------------*/
+
+function generateCiTypeDefs(configPath: string) {
+  return generateTypeDefs(configPath, '../stubs/tokenami.env.ci.d.ts');
+}
+
+/* -------------------------------------------------------------------------------------------------
  * getResponsivePropertyVariants
  * -----------------------------------------------------------------------------------------------*/
 
@@ -194,6 +202,7 @@ export {
   getCiTypeDefsPath,
   generateConfig,
   generateTypeDefs,
+  generateCiTypeDefs,
   getThemeValuesByTokenValues,
   getThemeValuesByThemeMode,
   getResponsivePropertyVariants,

--- a/packages/dev/stubs/tokenami.env.ci.d.ts
+++ b/packages/dev/stubs/tokenami.env.ci.d.ts
@@ -1,0 +1,8 @@
+/// <reference types="./tokenami.env.d.ts" />
+import type { Config } from './tokenami.env';
+
+declare module '@tokenami/dev' {
+  interface TokenamiConfig extends Config {
+    CI: true;
+  }
+}

--- a/packages/ts-plugin/package.json
+++ b/packages/ts-plugin/package.json
@@ -10,7 +10,8 @@
   "scripts": {
     "build": "tsc",
     "dev": "pnpm build --watch",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "typecheck:ci": "pnpm typecheck"
   },
   "dependencies": {
     "@tokenami/config": "workspace:*"

--- a/packages/ts-plugin/src/index.ts
+++ b/packages/ts-plugin/src/index.ts
@@ -17,6 +17,47 @@ function init(modules: { typescript: typeof tslib }) {
   const ts = modules.typescript;
   let entryConfigMap = new Map<string, EntryConfigItem>();
 
+  /* ---------------------------------------------------------------------------------------------
+   * getSelectorCompletions
+   * ---------------------------------------------------------------------------------------------
+   * we pre-compute selector entries to improve performance
+   * -------------------------------------------------------------------------------------------*/
+
+  function getSelectorCompletions(config: TokenamiConfig.Config): tslib.CompletionEntry[] {
+    const responsiveEntries = Object.entries(config.responsive || {});
+    const selectorsEntries = Object.entries(config.selectors || {});
+    const aliasProperties = Object.keys(config.aliases || {});
+
+    return [...Tokenami.supportedProperties, ...aliasProperties].flatMap((property) => {
+      const createCompletionEntry = createVariantPropertyEntry(property);
+      const entries = responsiveEntries.flatMap((entry) => {
+        const responsiveEntry = createCompletionEntry(entry);
+        const [responsiveSelector, responsiveValue] = entry;
+        const combinedEntries = selectorsEntries.map(([selector, value]) => {
+          const combinedSelector = `${responsiveSelector}_${selector}`;
+          const combinedValue = [responsiveValue].concat(value);
+          return createCompletionEntry([combinedSelector, combinedValue]);
+        });
+        return [responsiveEntry, ...combinedEntries];
+      });
+      return [...entries, ...selectorsEntries.map(createVariantPropertyEntry(property))];
+    });
+  }
+
+  /* ---------------------------------------------------------------------------------------------
+   * createVariantPropertyEntry
+   * -------------------------------------------------------------------------------------------*/
+
+  const createVariantPropertyEntry = (property: string) => {
+    return ([selector, value]: [string, string | string[]]) => {
+      const name = TokenamiConfig.variantProperty(selector, property);
+      const kind = tslib.ScriptElementKind.memberVariableElement;
+      const kindModifiers = tslib.ScriptElementKindModifier.optionalModifier;
+      updateEntryDetailsConfig({ name, kind, kindModifiers, value });
+      return { name, kind, kindModifiers, sortText: name, insertText: name };
+    };
+  };
+
   /* -----------------------------------------------------------------------------------------------
    * updateEntryDetailsConfig
    * ---------------------------------------------------------------------------------------------*/
@@ -98,12 +139,12 @@ function init(modules: { typescript: typeof tslib }) {
     }
 
     let config = Tokenami.getConfigAtPath(configPath);
-    let cachedCompletions: tslib.CompletionEntry[] | null;
+    let selectorCompletions = getSelectorCompletions(config);
 
     ts.sys.watchFile?.(configPath, (_, eventKind: tslib.FileWatcherEventKind) => {
       if (eventKind === modules.typescript.FileWatcherEventKind.Changed) {
         config = Tokenami.getReloadedConfigAtPath(configPath);
-        cachedCompletions = null;
+        selectorCompletions = getSelectorCompletions(config);
         info.project.refreshDiagnostics();
       }
     });
@@ -279,21 +320,17 @@ function init(modules: { typescript: typeof tslib }) {
           return entry;
         });
       } else if (isTokenPropertyEntries) {
-        if (cachedCompletions) {
-          info.project.projectService.logger.info(`TOKENAMI: using cached completions`);
-          original.entries = cachedCompletions;
-        } else {
-          info.project.projectService.logger.info(`TOKENAMI: caching completions`);
-          original.entries = cachedCompletions = original.entries.flatMap((entry) => {
-            const property = TokenamiConfig.TokenProperty.safeParse(entry.name);
-            entry.sortText = entry.name;
-            // filter any suggestions that aren't tokenami properties (e.g. backgroundColor)
-            if (!property.success) return [];
-            entry.sortText = getPropertySortText(property.output);
-            entry.insertText = property.output;
-            return [entry];
-          });
-        }
+        original.entries = original.entries.flatMap((entry) => {
+          const property = TokenamiConfig.TokenProperty.safeParse(entry.name);
+          entry.sortText = entry.name;
+          // filter any suggestions that aren't tokenami properties (e.g. backgroundColor)
+          if (!property.success) return [];
+          entry.sortText = '$' + property.output;
+          entry.insertText = property.output;
+          return [entry];
+        });
+
+        original.entries = original.entries.concat(selectorCompletions);
       }
 
       return original;
@@ -390,12 +427,5 @@ const createSquare = (color: string) => {
   const svg = `<svg width="10" height="10" xmlns="http://www.w3.org/2000/svg"><rect width="10" height="10" x="0" y="0" fill="${color}" /></svg>`;
   return `![Image](data:image/svg+xml;base64,${btoa(svg)})`;
 };
-
-function getPropertySortText(property: string) {
-  const sortKey = '$$$$';
-  const variantCount = (property.match('_') || []).length;
-  // we use $ to control order of properties. variants come last, base properties come first.
-  return sortKey.slice(0, sortKey.length - variantCount) + property;
-}
 
 export = init;


### PR DESCRIPTION
Reverts tokenami/tokenami#244

unfortunately when testing this on [a consumer project](https://github.com/pawelblaszczyk5/planner-tokenami), intellisense perf is significantly impacted for local dev w/o this workaround. i'm reverting for now to investigate further.