### PR TITLE
add exports to package.json for `@tokenami/config`, `@tokenami/css`, and `@tokenami/dev`

### DIFF
--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -2,11 +2,24 @@
   "name": "@tokenami/config",
   "version": "0.0.45",
   "license": "MIT",
-  "main": "./dist/index.js",
-  "module": "./dist/index.mjs",
+  "type": "module",
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "repository": "https://github.com/tokenami/tokenami",
   "sideEffects": false,
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      },
+      "require": {
+        "types": "./dist/index.d.cts",
+        "default": "./dist/index.cjs"
+      }
+    }
+  },
   "files": [
     "dist"
   ],

--- a/packages/css/package.json
+++ b/packages/css/package.json
@@ -8,6 +8,18 @@
   "types": "./dist/index.d.ts",
   "sideEffects": false,
   "repository": "https://github.com/tokenami/tokenami",
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      },
+      "require": {
+        "types": "./dist/index.d.cts",
+        "default": "./dist/index.cjs"
+      }
+    }
+  },
   "files": [
     "dist"
   ],

--- a/packages/dev/package.json
+++ b/packages/dev/package.json
@@ -7,6 +7,18 @@
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "repository": "https://github.com/tokenami/tokenami",
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      },
+      "require": {
+        "types": "./dist/index.d.cts",
+        "default": "./dist/index.cjs"
+      }
+    }
+  },
   "bin": {
     "tokenami": "bin.js"
   },


### PR DESCRIPTION
# Summary

i did a lil health-check [here](https://publint.dev/@tokenami/css@0.0.45) and realised i'd forgotten these.

## Change Type

Please indicate the type of change this is:

- [ ] `documentation`
- [x] `patch`
- [ ] `minor`
- [ ] `major`

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.0.46--canary.265.9035982041.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @tokenami/config@0.0.46--canary.265.9035982041.0
  npm install @tokenami/css@0.0.46--canary.265.9035982041.0
  npm install @tokenami/dev@0.0.46--canary.265.9035982041.0
  npm install @tokenami/ts-plugin@0.0.46--canary.265.9035982041.0
  # or 
  yarn add @tokenami/config@0.0.46--canary.265.9035982041.0
  yarn add @tokenami/css@0.0.46--canary.265.9035982041.0
  yarn add @tokenami/dev@0.0.46--canary.265.9035982041.0
  yarn add @tokenami/ts-plugin@0.0.46--canary.265.9035982041.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
