### PR TITLE
bug: grid vars aren't being inferred onto relevant property type

### DIFF
--- a/examples/design-system/.tokenami/tokenami.config.ts
+++ b/examples/design-system/.tokenami/tokenami.config.ts
@@ -19,6 +19,9 @@ const theme = {
   border: {
     thin: '1px solid var(--color_slate-700)',
   },
+  grid: {
+    small: '8px',
+  },
   font: {
     serif: 'serif',
     sans: 'sans-serif',

--- a/examples/design-system/src/button/button.tsx
+++ b/examples/design-system/src/button/button.tsx
@@ -6,7 +6,7 @@ import { type Variants, type TokenamiStyle, css } from '~/css';
  * -----------------------------------------------------------------------------------------------*/
 
 type ButtonElementProps = React.ComponentPropsWithoutRef<'button'>;
-interface ButtonProps extends TokenamiStyle<ButtonElementProps>, Variants<typeof button> {}
+interface ButtonProps extends TokenamiStyle<ButtonElementProps>, Variants<typeof button> { }
 
 const Button = React.forwardRef<HTMLButtonElement, ButtonProps>((props, forwardedRef) => {
   const { size = 'small', children, ...buttonProps } = props;
@@ -23,6 +23,8 @@ const button = css.compose({
   '--border': 'var(---,none)',
   '--border-bottom': 'var(---, 2px solid var(--color_slate-700))',
   '--border-radius': 'var(--radii_rounded)',
+  '--padding-left': 'var(--grid_small)',
+  //                 ^? Type '"var(--grid_small)"' is not assignable to type 'number | Globals | `var(---,${string})` | undefined'.ts(2322)
   '--font-family': 'var(--font_sans)',
   '--width': 'var(---,180px)',
   '--height': 15,


### PR DESCRIPTION
# Summary

**Disclaimer: This is actually a bug report (no need to merge this PR) – aka. PR as a minimal reproducible example.**

It seems that when I add some `grid` tokens to my system, those variables aren't being inferred onto the `css` properties that support `grid` vars.
