### PR TITLE
include missing quotes in property insert text

### DIFF
--- a/packages/ts-plugin/src/index.ts
+++ b/packages/ts-plugin/src/index.ts
@@ -55,11 +55,12 @@ function init(modules: { typescript: typeof tslib }) {
 
   const createVariantPropertyEntry = (property: string) => {
     return ([selector, value]: [string, string | string[]]) => {
-      const name = TokenamiConfig.variantProperty(selector, property);
+      const tokenProperty = TokenamiConfig.variantProperty(selector, property);
+      const name = `\"${tokenProperty}\"`;
       const kind = tslib.ScriptElementKind.memberVariableElement;
       const kindModifiers = tslib.ScriptElementKindModifier.optionalModifier;
       updateEntryDetailsConfig({ name, kind, kindModifiers, value });
-      return { name: `\"${name}\"`, kind, kindModifiers, sortText: name, insertText: name };
+      return { name: name, kind, kindModifiers, sortText: name, insertText: name };
     };
   };
 


### PR DESCRIPTION
# Summary

this was working well for base properties but variant properties (responsive/selectors) were broken. 

| BEFORE | AFTER |
| - | - |
| <video src="https://github.com/tokenami/tokenami/assets/175330/11d8df4c-ad6b-4f70-807b-2bb6bcca2dab" controls="controls" muted="muted" class="d-block rounded-bottom-2 border-top width-fit" style="max-height:640px; min-height: 200px"></video> | <video src="https://github.com/tokenami/tokenami/assets/175330/b70a8e18-e935-432a-a9f2-e4733b7e6848" controls="controls" muted="muted" class="d-block rounded-bottom-2 border-top width-fit" style="max-height:640px; min-height: 200px"></video> | 

## Change Type

Please indicate the type of change this is:

- [ ] `documentation`
- [x] `patch`
- [ ] `minor`
- [ ] `major`
