### PR TITLE
provide ts errors for invalid selectors with special chars

### DIFF
--- a/packages/dev/src/sheet.ts
+++ b/packages/dev/src/sheet.ts
@@ -51,7 +51,7 @@ function generate(params: {
   };
 
   propertyConfigsByCSSProperty.forEach((configs, cssProperty) => {
-    const isLogical = supportedLogicalProperties.includes(cssProperty as any);
+    const isLogical = supportedLogicalProperties.has(cssProperty as any);
     // sort configs to ensure property value orders fallbacks correctly
     const sortedConfigs = [...configs].sort((a, b) => a.order - b.order);
     const variants = sortedConfigs.flatMap((config) => (config.variant ? [config.variant] : []));
@@ -176,7 +176,7 @@ function getPropertyConfigs(
 const SHORTHAND_TO_LONGHAND_ENTRIES = Object.entries(Tokenami.mapShorthandToLonghands);
 
 function getAtomicLayer(cssProperty: string): number {
-  const isSupported = (supportedProperties as string[]).includes(cssProperty);
+  const isSupported = supportedProperties.has(cssProperty as any);
   const initialDepth = isSupported ? 1 : -1;
 
   if (cssProperty === 'all') return 0;

--- a/packages/dev/src/supports.ts
+++ b/packages/dev/src/supports.ts
@@ -488,8 +488,8 @@ const supported: AllProperties = {
 };
 
 type LogicalProperties = keyof typeof supportedLogical;
-const supportedProperties = Object.keys(supported) as CSSProperty[];
-const supportedLogicalProperties = Object.keys(supportedLogical) as LogicalProperties[];
+const supportedProperties = new Set(Object.keys(supported)) as Set<CSSProperty>;
+const supportedLogicalProperties = new Set(Object.keys(supportedLogical)) as Set<LogicalProperties>;
 
 export type { CSSProperty };
 export { supportedProperties, supportedLogicalProperties };

--- a/packages/dev/tsup.config.ts
+++ b/packages/dev/tsup.config.ts
@@ -1,7 +1,7 @@
 import { defineConfig } from 'tsup';
 
 export default defineConfig({
-  entry: ['src/index.ts', 'src/declarations.ts', 'src/cli.ts'],
+  entry: ['src/index.ts', 'src/cli.ts'],
   format: ['cjs', 'esm'],
   dts: true,
   shims: true,


### PR DESCRIPTION
# Summary

also: 

- fixes the quoted/unquoted completions properly. which i'd attempted (badly) in [a previous pr](https://github.com/tokenami/tokenami/pull/270)
- updates arbitrary value quick fix to insert `var(---, value)` instead of `var(---,value)`
- removes cache for `getCompletionsAtPosition` because it was contributing to quote/unquoted completion issues
- prevents `getQuickInfoAtPosition` for invalid properties (properties w/ bad selectors)
- some housekeeping/refactoring to help me understand wtf i'm doing next time i visit this stuff


## Change Type

<!-- Please indicate the type of change this is -->

- [ ] `documentation`
- [ ] `patch`
- [x] `minor`
- [ ] `major`

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.0.48--canary.273.9237026283.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @tokenami/config@0.0.48--canary.273.9237026283.0
  npm install @tokenami/css@0.0.48--canary.273.9237026283.0
  npm install @tokenami/dev@0.0.48--canary.273.9237026283.0
  npm install @tokenami/ts-plugin@0.0.48--canary.273.9237026283.0
  # or 
  yarn add @tokenami/config@0.0.48--canary.273.9237026283.0
  yarn add @tokenami/css@0.0.48--canary.273.9237026283.0
  yarn add @tokenami/dev@0.0.48--canary.273.9237026283.0
  yarn add @tokenami/ts-plugin@0.0.48--canary.273.9237026283.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
