### PR TITLE
arbitrary selector support

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -3,3 +3,4 @@ strict-peer-dependencies=false
 auto-install-peers=true
 link-workspace-packages=true
 prefer-workspace-packages=true
+shamefully-hoist=true # needed for the ts=plugin

--- a/README.md
+++ b/README.md
@@ -244,6 +244,22 @@ module.exports = createConfig({
 });
 ```
 
+#### Arbitrary selectors
+
+Use arbitrary selectors to prototype quickly:
+
+```tsx
+<div
+  style={css({
+    '--[&:hover]_color': 'var(--color_primary)',
+    '--[&:has(:focus)]_border-color': 'var(--color_highlight)',
+    '--[&:[data-state=open]]_border-color': 'var(--color_primary)',
+  })}
+/>
+```
+
+They can be used to style the **current element, and its descendants** only.
+
 #### Arbitrary values
 
 You can avoid TypeScript errors for one-off inline values by using a triple dash fallback. For instance, `--padding: var(---, 20px)` prevents errors and sets padding to `20px`.

--- a/README.md
+++ b/README.md
@@ -251,9 +251,9 @@ Use arbitrary selectors to prototype quickly:
 ```tsx
 <div
   style={css({
-    '--[&:hover]_color': 'var(--color_primary)',
-    '--[&:has(:focus)]_border-color': 'var(--color_highlight)',
-    '--[&:[data-state=open]]_border-color': 'var(--color_primary)',
+    '--{&:hover}_color': 'var(--color_primary)',
+    '--{&:has(:focus)}_border-color': 'var(--color_highlight)',
+    '--{&:[data-state=open]}_border-color': 'var(--color_primary)',
   })}
 />
 ```

--- a/examples/design-system/.tokenami/tokenami.config.ts
+++ b/examples/design-system/.tokenami/tokenami.config.ts
@@ -76,7 +76,6 @@ export default createConfig({
   },
   selectors: {
     ...defaultConfig.selectors,
-    'focus-hover': '&:focus:hover',
     hover: ['@media (hover: hover) and (pointer: fine)', '&:hover'],
   },
   aliases: {

--- a/examples/design-system/src/button/button.tsx
+++ b/examples/design-system/src/button/button.tsx
@@ -31,6 +31,7 @@ const button = css.compose({
   '--hover_background-color': 'var(--color_slate-700)',
   '--hover_color': 'var(---,white)',
   '--hover_animation': 'var(--anim_wiggle)',
+  '--{&:focus:hover}_background-color': 'var(---, red)',
 
   responsiveVariants: {
     size: {

--- a/examples/design-system/src/css.ts
+++ b/examples/design-system/src/css.ts
@@ -2,4 +2,4 @@ import { createCss } from '@tokenami/css';
 import config from '../.tokenami/tokenami.config';
 
 export type * from '@tokenami/css';
-export const css = createCss(config);
+export const css = createCss(config, { escapeSpecialChars: false });

--- a/examples/design-system/src/tokenami.css
+++ b/examples/design-system/src/tokenami.css
@@ -44,6 +44,8 @@ body {
     --background-color: initial;
     --hover: initial;
     --hover_background-color: initial;
+    --\{\&\;focus\;hover\}: initial;
+    --\{\&\;focus\;hover\}_background-color: initial;
     --color: initial;
     --hover_color: initial;
     --border: initial;
@@ -96,8 +98,9 @@ body {
 
   @layer tks2 {
     [style] {
-      background-color: var(--_4dvc60, revert-layer);
+      background-color: var(--_1r7lnia, var(--_4dvc60, revert-layer));
       --_4dvc60: var(--hover) var(--hover_background-color);
+      --_1r7lnia: var(--\{\&\;focus\;hover\}) var(--\{\&\;focus\;hover\}_background-color);
       font-size: var(--_1qfo97, var(--_1tqbkib, var(--_1283h2s, var(--_1pod6o8, revert-layer))));
       --_1pod6o8: var(--md) var(--md_font-size);
       --_1283h2s: var(--lg) var(--lg_font-size);
@@ -110,6 +113,10 @@ body {
     [style]:hover {
       --hover: ;
     }
+  }
+
+  [style]:focus:hover {
+    --\{\&\;focus\;hover\}: ;
   }
 
   @media (min-width: 700px) {

--- a/examples/remix/app/routes/_index.tsx
+++ b/examples/remix/app/routes/_index.tsx
@@ -109,8 +109,7 @@ export default function Index() {
           '--hover_color': 'var(---,white)',
           '--transition': 'var(---,all 150ms)',
           '--hover_animation': 'var(--anim_wiggle)',
-          '--{&:focus:hover}_background-color': 'var(--color_slate-700)',
-          '--md_{&:focus:hover}_background-color': 'var(--color_sky-500)',
+          '--{&:focus:hover}_background-color': 'var(--color_sky-500)',
         })}
       >
         Button

--- a/examples/remix/app/routes/_index.tsx
+++ b/examples/remix/app/routes/_index.tsx
@@ -109,8 +109,8 @@ export default function Index() {
           '--hover_color': 'var(---,white)',
           '--transition': 'var(---,all 150ms)',
           '--hover_animation': 'var(--anim_wiggle)',
-          '--[&:focus:hover]_background-color': 'var(--color_slate-700)',
-          '--md_[&:focus:hover]_background-color': 'var(--color_sky-500)',
+          '--{&:focus:hover}_background-color': 'var(--color_slate-700)',
+          '--md_{&:focus:hover}_background-color': 'var(--color_sky-500)',
         })}
       >
         Button

--- a/examples/remix/app/routes/_index.tsx
+++ b/examples/remix/app/routes/_index.tsx
@@ -109,8 +109,8 @@ export default function Index() {
           '--hover_color': 'var(---,white)',
           '--transition': 'var(---,all 150ms)',
           '--hover_animation': 'var(--anim_wiggle)',
-          '--focus-hover_background-color': 'var(--color_slate-700)',
-          '--md_focus-hover_background-color': 'var(--color_sky-500)',
+          '--[&:focus:hover]_background-color': 'var(--color_slate-700)',
+          '--md_[&:focus:hover]_background-color': 'var(--color_sky-500)',
         })}
       >
         Button

--- a/examples/remix/public/tokenami.css
+++ b/examples/remix/public/tokenami.css
@@ -65,10 +65,6 @@ body {
     --child-para: initial;
     --select: initial;
     --select_background-color: initial;
-    --focus-hover: initial;
-    --focus-hover_background-color: initial;
-    --md_focus-hover: initial;
-    --md_focus-hover_background-color: initial;
     --color: initial;
     --hover_color: initial;
     --select_color: initial;
@@ -244,12 +240,10 @@ body {
 
   @layer tks2 {
     [style], [style] > p, [style*="select_"]::selection, [style]:after {
-      background-color: var(--_1atsbkt, var(--_g2kfvl, var(--_3prh80, var(--_1chvnfl, var(--_4dvc60, revert-layer)))));
+      background-color: var(--_3prh80, var(--_1chvnfl, var(--_4dvc60, revert-layer)));
       --_4dvc60: var(--hover) var(--hover_background-color);
       --_1chvnfl: var(--child-para) var(--child-para_background-color);
       --_3prh80: var(--select) var(--select_background-color);
-      --_g2kfvl: var(--focus-hover) var(--focus-hover_background-color);
-      --_1atsbkt: var(--md_focus-hover) var(--md_focus-hover_background-color);
       font-size: var(--_1qfo97, var(--_1tqbkib, var(--_1283h2s, var(--_1pod6o8, revert-layer))));
       --_1pod6o8: var(--md) var(--md_font-size);
       --_1283h2s: var(--lg) var(--lg_font-size);
@@ -276,15 +270,7 @@ body {
     --select: ;
   }
 
-  [style]:focus:hover {
-    --focus-hover: ;
-  }
-
   @media (width >= 700px) {
-    [style]:focus:hover {
-      --md_focus-hover: ;
-    }
-
     [style] {
       --md: ;
     }

--- a/examples/remix/public/tokenami.css
+++ b/examples/remix/public/tokenami.css
@@ -62,13 +62,11 @@ body {
     --background-color: initial;
     --hover: initial;
     --hover_background-color: initial;
+    --\{\&\;focus\;hover\}: initial;
+    --\{\&\;focus\;hover\}_background-color: initial;
     --child-para: initial;
     --select: initial;
     --select_background-color: initial;
-    --\{\&-focus-hover\}: initial;
-    --\{\&-focus-hover\}_background-color: initial;
-    --md_\{\&-focus-hover\}: initial;
-    --md_\{\&-focus-hover\}_background-color: initial;
     --color: initial;
     --hover_color: initial;
     --select_color: initial;
@@ -244,12 +242,12 @@ body {
 
   @layer tks2 {
     [style], [style] > p, [style*="select_"]::selection, [style]:after {
-      background-color: var(--_113hhoe, var(--_1r7lnia, var(--_3prh80, var(--_1chvnfl, var(--_4dvc60, revert-layer)))));
+      background-color: var(--_1r7lnia, var(--_3prh80, var(--_1chvnfl, var(--_1fio48, var(--_4dvc60, revert-layer)))));
       --_4dvc60: var(--hover) var(--hover_background-color);
+      --_1fio48: var(--\{\&\;focus\;hover\}) var(--\{\&\;focus\;hover\}_background-color);
       --_1chvnfl: var(--child-para) var(--child-para_background-color);
       --_3prh80: var(--select) var(--select_background-color);
-      --_1r7lnia: var(--\{\&-focus-hover\}) var(--\{\&-focus-hover\}_background-color);
-      --_113hhoe: var(--md_\{\&-focus-hover\}) var(--md_\{\&-focus-hover\}_background-color);
+      --_1r7lnia: var(--\{\&\;focus\;hover\}) var(--\{\&\;focus\;hover\}_background-color);
       font-size: var(--_1qfo97, var(--_1tqbkib, var(--_1283h2s, var(--_1pod6o8, revert-layer))));
       --_1pod6o8: var(--md) var(--md_font-size);
       --_1283h2s: var(--lg) var(--lg_font-size);
@@ -277,14 +275,10 @@ body {
   }
 
   [style]:focus:hover {
-    --\{\&-focus-hover\}: ;
+    --\{\&\;focus\;hover\}: ;
   }
 
   @media (width >= 700px) {
-    [style]:focus:hover {
-      --md_\{\&-focus-hover\}: ;
-    }
-
     [style] {
       --md: ;
     }

--- a/examples/remix/public/tokenami.css
+++ b/examples/remix/public/tokenami.css
@@ -65,6 +65,10 @@ body {
     --child-para: initial;
     --select: initial;
     --select_background-color: initial;
+    --\{\&-focus-hover\}: initial;
+    --\{\&-focus-hover\}_background-color: initial;
+    --md_\{\&-focus-hover\}: initial;
+    --md_\{\&-focus-hover\}_background-color: initial;
     --color: initial;
     --hover_color: initial;
     --select_color: initial;
@@ -240,10 +244,12 @@ body {
 
   @layer tks2 {
     [style], [style] > p, [style*="select_"]::selection, [style]:after {
-      background-color: var(--_3prh80, var(--_1chvnfl, var(--_4dvc60, revert-layer)));
+      background-color: var(--_113hhoe, var(--_1r7lnia, var(--_3prh80, var(--_1chvnfl, var(--_4dvc60, revert-layer)))));
       --_4dvc60: var(--hover) var(--hover_background-color);
       --_1chvnfl: var(--child-para) var(--child-para_background-color);
       --_3prh80: var(--select) var(--select_background-color);
+      --_1r7lnia: var(--\{\&-focus-hover\}) var(--\{\&-focus-hover\}_background-color);
+      --_113hhoe: var(--md_\{\&-focus-hover\}) var(--md_\{\&-focus-hover\}_background-color);
       font-size: var(--_1qfo97, var(--_1tqbkib, var(--_1283h2s, var(--_1pod6o8, revert-layer))));
       --_1pod6o8: var(--md) var(--md_font-size);
       --_1283h2s: var(--lg) var(--lg_font-size);
@@ -270,7 +276,15 @@ body {
     --select: ;
   }
 
+  [style]:focus:hover {
+    --\{\&-focus-hover\}: ;
+  }
+
   @media (width >= 700px) {
+    [style]:focus:hover {
+      --md_\{\&-focus-hover\}: ;
+    }
+
     [style] {
       --md: ;
     }

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "prepare": "turbo run build",
     "dev": "turbo run dev --filter=@tokenami/example-remix",
     "dev:ds": "turbo run dev --filter=@tokenami/example-design-system",
-    "build": "turbo run build",
+    "build": "turbo run build --filter='./packages/*'",
     "clean": "pnpm exec rm -rf node_modules .turbo && pnpm -r exec rm -rf node_modules .turbo dist",
     "typecheck": "turbo run typecheck",
     "typecheck:ci": "turbo run typecheck:ci",

--- a/packages/config/src/common.ts
+++ b/packages/config/src/common.ts
@@ -1,8 +1,5 @@
 import { type Config } from './config';
 
-const SPECIAL_CHAR = '!#$%&()*+,./:;<=>?@[\\]^{|}~';
-const REGULAR_CHAR = 'A-Za-z0-9_';
-
 /* -------------------------------------------------------------------------------------------------
  * GridProperty
  * -----------------------------------------------------------------------------------------------*/
@@ -34,9 +31,9 @@ const GridValue = {
  * -----------------------------------------------------------------------------------------------*/
 
 type TokenProperty<P extends string = string> = `--${P}`;
-const tokenPropertyRegex = new RegExp(
-  `(?<!var\\()--[${REGULAR_CHAR}${SPECIAL_CHAR}]([${REGULAR_CHAR}${SPECIAL_CHAR}-]+)?`
-);
+// thanks chat gpt. will match css variable names that start with `--` and handle nested square
+// brackets, while excluding those prefixed with `var(`
+const tokenPropertyRegex = /(?<!var\()--(?:[\w-]+|\[[^\[\]]*(?:\[[^\[\]]*\][^\[\]]*)*\])+/g;
 
 const TokenProperty = {
   safeParse: (input: unknown) => validate<TokenProperty>(tokenPropertyRegex, input),
@@ -199,7 +196,7 @@ function getCSSPropertiesForAlias(alias: string, aliases: Config['aliases']): st
  * escapeSpecialChars
  * -----------------------------------------------------------------------------------------------*/
 
-const escapeSpecialCharsRegex = new RegExp(`[${SPECIAL_CHAR}]`, 'g');
+const escapeSpecialCharsRegex = /[!#$%&()*+,./:;<=>?@[\]^{|}~"']/g;
 
 function escapeSpecialChars<T extends string>(str: T) {
   // escape and replace colons with hypens for improved dev tooling exp

--- a/packages/config/src/common.ts
+++ b/packages/config/src/common.ts
@@ -202,7 +202,11 @@ function getCSSPropertiesForAlias(alias: string, aliases: Config['aliases']): st
 const escapeSpecialCharsRegex = new RegExp(`[${SPECIAL_CHAR}]`, 'g');
 
 function escapeSpecialChars<T extends string>(str: T) {
-  return str.replace(escapeSpecialCharsRegex, (match) => `\\${match}`) as T;
+  // escape and replace colons with hypens for improved dev tooling exp
+  // - there is a bug here https://issues.chromium.org/u/1/issues/342857961 but;
+  // - var name colons in `style` attribute can be confusing because colons usually
+  //   delimit property/value pairs there
+  return str.replace(escapeSpecialCharsRegex, (match) => `\\${match}`).replace(/:/g, '-') as T;
 }
 
 /* ---------------------------------------------------------------------------------------------- */

--- a/packages/config/src/common.ts
+++ b/packages/config/src/common.ts
@@ -226,4 +226,5 @@ export {
   getTokenValueParts,
   getArbitrarySelector,
   getCSSPropertiesForAlias,
+  escapeSpecialChars,
 };

--- a/packages/config/tsup.config.ts
+++ b/packages/config/tsup.config.ts
@@ -1,7 +1,7 @@
 import { defineConfig } from 'tsup';
 
 export default defineConfig({
-  entry: ['./src'],
+  entry: ['./src/index.ts'],
   format: ['cjs', 'esm'],
   splitting: false,
   treeshake: true,

--- a/packages/css/src/css.ts
+++ b/packages/css/src/css.ts
@@ -1,16 +1,11 @@
 import type { TokenamiProperties, TokenamiFinalConfig } from '@tokenami/dev';
 import * as Tokenami from '@tokenami/config';
 
-const _ALIASES = Symbol();
+const _TOKENAMI_CSS = Symbol.for('@tokenami/css');
 
 // return type purposfully isn't `TokenamiProperties` bcos frameworks limit the `style`
 // types to `CSS.PropertiesHyphen` or `CSS.Properties` which doesn't include `--custom-properties`
 type TokenamiCSS = { [_: symbol]: 'TokenamiCSS' };
-
-/* -------------------------------------------------------------------------------------------------
- * css
- * -----------------------------------------------------------------------------------------------*/
-
 type VariantsConfig = Record<string, Record<string, TokenamiProperties>>;
 type VariantValue<T> = T extends 'true' | 'false' ? boolean : T;
 type ReponsiveKey = Extract<keyof TokenamiFinalConfig['responsive'], string>;
@@ -27,8 +22,6 @@ type ComposeCSS<V, R> = TokenamiProperties & {
 };
 
 interface CSS {
-  [_ALIASES]?: Tokenami.Aliases;
-
   // return type is purposfully `{}` to support `style` attribute type for different frameworks.
   // returning `TokenamiProperties` is not enough here bcos that type can create circular refs
   // in frameworks like SolidJS that use `CSS.PropertiesHyphen` as style attr type. i'm unsure
@@ -67,92 +60,101 @@ const cache = {
   },
 };
 
-const css: CSS = (baseStyles, ...overrides) => {
-  let overriddenStyles = {} as TokenamiCSS;
-  const cacheId = JSON.stringify({ baseStyles, overrides });
-  const cached = cache.get(cacheId);
-
-  if (cached) return cached;
-
-  [baseStyles, ...overrides].forEach((originalStyles) => {
-    if (!originalStyles) return;
-    Object.entries(originalStyles).forEach(([key, value]) => {
-      if (!Tokenami.TokenProperty.safeParse(key).success) return;
-      // we purposefully don't use property.output here bcos custom css vars
-      // are prefixed w/ triple dash and we want those to remain as is.
-      // safeParse acts like zod, its output matches a Tokenami TokenProperty
-      // shape exactly (two hyphens).
-      const tokenProperty = key as keyof TokenamiProperties;
-      const parts = Tokenami.getTokenPropertySplit(tokenProperty);
-      const cssProperties = Tokenami.getCSSPropertiesForAlias(parts.alias, css[_ALIASES]);
-
-      cssProperties.forEach((cssProperty) => {
-        const tokenPropertyLong = createEscapedLonghandProperty(tokenProperty, cssProperty);
-
-        if (typeof value === 'number' && value > 0) {
-          const gridVar = Tokenami.gridProperty();
-          value = `calc(var(${gridVar}) * ${value})`;
-        }
-
-        overrideLonghands(overriddenStyles, tokenPropertyLong);
-        // this must happen each iteration so that each override applies to the
-        // mutated css object from the previous override iteration
-        Object.assign(overriddenStyles, { [tokenPropertyLong]: value });
-      });
-    });
-  });
-
-  cache.set(cacheId, overriddenStyles);
-  return overriddenStyles;
-};
-
-css[_ALIASES] = {};
-
-/* -------------------------------------------------------------------------------------------------
- * compose
- * -----------------------------------------------------------------------------------------------*/
-
-css.compose = (config) => {
-  const { variants, responsiveVariants, ...baseStyles } = config;
-
-  return function generate(selectedVariants, ...overrides) {
-    const cacheId = JSON.stringify({
-      baseStyles,
-      variants,
-      responsiveVariants,
-      selectedVariants,
-      overrides,
-    });
-    const cached = cache.get(cacheId);
-    if (cached) return cached;
-
-    const variantStyles: TokenamiProperties[] = selectedVariants
-      ? Object.entries(selectedVariants).flatMap(([key, variant]) => {
-          if (!variant) return [];
-          const [type, bp] = key.split('_').reverse() as [keyof VariantsConfig, string?];
-          if (bp) {
-            const styles = responsiveVariants?.[type]?.[variant as any];
-            return styles ? [convertToMediaStyles(bp, styles)] : [];
-          } else {
-            const styles = (variants || responsiveVariants)?.[type]?.[variant as any];
-            return styles ? [styles] : [];
-          }
-        })
-      : [];
-
-    const styles = css(baseStyles, ...variantStyles, ...overrides);
-    cache.set(cacheId, styles);
-    return styles;
-  };
-};
-
 /* -------------------------------------------------------------------------------------------------
  * createCss
  * -----------------------------------------------------------------------------------------------*/
 
-function createCss(config: Tokenami.Config) {
-  if (!config.aliases) return css;
-  css[_ALIASES] = config.aliases;
+type CreateCssOptions = {
+  /**
+   * When using arbitrary values, Tokenami will escape special characters. Some frameworks
+   * automatically escape so this would result in double-escaping. In that case, switch this
+   * off to hand-off to your framework.
+   *
+   * @default true
+   */
+  escapeSpecialChars?: boolean;
+};
+
+function createCss(config: Tokenami.Config, options?: CreateCssOptions) {
+  (globalThis as any)[_TOKENAMI_CSS] = options || {};
+  const globalOptions: CreateCssOptions = (globalThis as any)[_TOKENAMI_CSS];
+
+  const css: CSS = (baseStyles, ...overrides) => {
+    let overriddenStyles = {} as TokenamiCSS;
+    const cacheId = JSON.stringify({ baseStyles, overrides });
+    const cached = cache.get(cacheId);
+
+    if (cached) return cached;
+
+    [baseStyles, ...overrides].forEach((originalStyles) => {
+      if (!originalStyles) return;
+      Object.entries(originalStyles).forEach(([key, value]) => {
+        const tokenProperty = Tokenami.TokenProperty.safeParse(key);
+        if (!tokenProperty.success) {
+          Object.assign(overriddenStyles, { [key]: value });
+          return;
+        }
+
+        const parts = Tokenami.getTokenPropertySplit(tokenProperty.output);
+        const cssProperties = Tokenami.getCSSPropertiesForAlias(parts.alias, config.aliases);
+
+        cssProperties.forEach((cssProperty) => {
+          const long = createLonghandProperty(tokenProperty.output, cssProperty);
+          const tokenPropertyLong = Tokenami.parseProperty(long, {
+            escapeSpecialChars: globalOptions?.escapeSpecialChars,
+          });
+
+          if (typeof value === 'number' && value > 0) {
+            const gridVar = Tokenami.gridProperty();
+            value = `calc(var(${gridVar}) * ${value})`;
+          }
+
+          overrideLonghands(overriddenStyles, tokenPropertyLong);
+          // this must happen each iteration so that each override applies to the
+          // mutated css object from the previous override iteration
+          Object.assign(overriddenStyles, { [tokenPropertyLong]: value });
+        });
+      });
+    });
+
+    cache.set(cacheId, overriddenStyles);
+    return overriddenStyles;
+  };
+
+  css.compose = (config) => {
+    const { variants, responsiveVariants, ...baseStyles } = config;
+
+    return function generate(selectedVariants, ...overrides) {
+      const cacheId = JSON.stringify({
+        baseStyles,
+        variants,
+        responsiveVariants,
+        selectedVariants,
+        overrides,
+      });
+      const cached = cache.get(cacheId);
+      if (cached) return cached;
+
+      const variantStyles: TokenamiProperties[] = selectedVariants
+        ? Object.entries(selectedVariants).flatMap(([key, variant]) => {
+            if (!variant) return [];
+            const [type, bp] = key.split('_').reverse() as [keyof VariantsConfig, string?];
+            if (bp) {
+              const styles = responsiveVariants?.[type]?.[variant as any];
+              return styles ? [convertToMediaStyles(bp, styles)] : [];
+            } else {
+              const styles = (variants || responsiveVariants)?.[type]?.[variant as any];
+              return styles ? [styles] : [];
+            }
+          })
+        : [];
+
+      const styles = css(baseStyles, ...variantStyles, ...overrides);
+      cache.set(cacheId, styles);
+      return styles;
+    };
+  };
+
   return css;
 }
 
@@ -164,21 +166,20 @@ function overrideLonghands(style: Record<string, any>, tokenProperty: Tokenami.T
   const parts = Tokenami.getTokenPropertySplit(tokenProperty);
   const longhands: string[] = Tokenami.mapShorthandToLonghands.get(parts.alias as any) || [];
   longhands.forEach((longhand) => {
-    const tokenPropertyLong = createEscapedLonghandProperty(tokenProperty, longhand);
+    const tokenPropertyLong = createLonghandProperty(tokenProperty, longhand);
     if (style[tokenPropertyLong]) delete style[tokenPropertyLong];
     overrideLonghands(style, tokenPropertyLong);
   });
 }
 
 /* -------------------------------------------------------------------------------------------------
- * createEscapedLonghandProperty
+ * createLonghandProperty
  * -----------------------------------------------------------------------------------------------*/
 
-function createEscapedLonghandProperty(tokenProperty: Tokenami.TokenProperty, cssProperty: string) {
+function createLonghandProperty(tokenProperty: Tokenami.TokenProperty, cssProperty: string) {
   const parts = Tokenami.getTokenPropertySplit(tokenProperty);
   const aliasRegex = new RegExp(`${parts.alias}$`);
-  const escaped = Tokenami.escapeSpecialChars(tokenProperty.replace(aliasRegex, cssProperty));
-  return escaped as Tokenami.TokenProperty;
+  return tokenProperty.replace(aliasRegex, cssProperty) as Tokenami.TokenProperty;
 }
 
 /* -------------------------------------------------------------------------------------------------
@@ -188,7 +189,7 @@ function createEscapedLonghandProperty(tokenProperty: Tokenami.TokenProperty, cs
 function convertToMediaStyles(bp: string, styles: TokenamiProperties): TokenamiProperties {
   const updatedEntries = Object.entries(styles).map(([property, value]) => {
     const tokenPrefix = Tokenami.tokenProperty('');
-    const bpPrefix = Tokenami.variantProperty(bp, '');
+    const bpPrefix = Tokenami.parsedVariantProperty(bp, '');
     const bpProperty = property.replace(tokenPrefix, bpPrefix);
     return [bpProperty, value];
   });
@@ -196,6 +197,8 @@ function convertToMediaStyles(bp: string, styles: TokenamiProperties): TokenamiP
 }
 
 /* ---------------------------------------------------------------------------------------------- */
+
+const css = createCss(Tokenami.defaultConfig, { escapeSpecialChars: true });
 
 export type { TokenamiCSS, CSS };
 export { createCss, css, convertToMediaStyles };

--- a/packages/dev/src/cli.ts
+++ b/packages/dev/src/cli.ts
@@ -192,7 +192,7 @@ async function findUsedTokens(cwd: string, config: Tokenami.Config): Promise<Use
 const CSS_VARIABLE_REGEX = /--(?:[\w-]+|\{[^\{\}]*\})+/g;
 
 function matchTokens(content: string, theme: Tokenami.Config['theme']) {
-  const matches = Array.from(content.match(CSS_VARIABLE_REGEX) || []);
+  const matches = Array.from(content.replace(/\\/g, '').match(CSS_VARIABLE_REGEX) || []);
   const uniqueMatches = utils.unique(matches);
   const variableMatches = uniqueMatches.filter((match) => match !== Tokenami.gridProperty());
 

--- a/packages/dev/src/cli.ts
+++ b/packages/dev/src/cli.ts
@@ -184,11 +184,12 @@ async function findUsedTokens(cwd: string, config: Tokenami.Config): Promise<Use
  * matchTokens
  * -----------------------------------------------------------------------------------------------*/
 
-// we match all css variable looking things and determine whether they're a tokenami value/property
+// we match all css variable looking things (including special chars within square brackets only
+// for arbitrary selectors) and determine whether they're a tokenami value/property
 // based on tokenami config. we purposefully don't match `var(...)` for values because we want
 // consumers to be able to pass a generated stylesheet to `includes` to support external design
 // system packages.
-const CSS_VARIABLE_REGEX = /--[\w-]+/g;
+const CSS_VARIABLE_REGEX = /--(([\w-]+|\[[^\]]*\])+)/g;
 
 function matchTokens(content: string, theme: Tokenami.Config['theme']) {
   const matches = Array.from(content.match(CSS_VARIABLE_REGEX) || []);

--- a/packages/dev/src/cli.ts
+++ b/packages/dev/src/cli.ts
@@ -184,12 +184,12 @@ async function findUsedTokens(cwd: string, config: Tokenami.Config): Promise<Use
  * matchTokens
  * -----------------------------------------------------------------------------------------------*/
 
-// we match all css variable looking things (including special chars within square brackets only
+// we match all css variable looking things (including special chars within square brackets
 // for arbitrary selectors) and determine whether they're a tokenami value/property
 // based on tokenami config. we purposefully don't match `var(...)` for values because we want
 // consumers to be able to pass a generated stylesheet to `includes` to support external design
-// system packages.
-const CSS_VARIABLE_REGEX = /--(([\w-]+|\[[^\]]*\])+)/g;
+// system packages (thanks chat gpt)
+const CSS_VARIABLE_REGEX = /--(?:[\w-]+|\[[^\[\]]*(?:\[[^\[\]]*\][^\[\]]*)*\])+/g;
 
 function matchTokens(content: string, theme: Tokenami.Config['theme']) {
   const matches = Array.from(content.match(CSS_VARIABLE_REGEX) || []);

--- a/packages/dev/src/cli.ts
+++ b/packages/dev/src/cli.ts
@@ -184,12 +184,12 @@ async function findUsedTokens(cwd: string, config: Tokenami.Config): Promise<Use
  * matchTokens
  * -----------------------------------------------------------------------------------------------*/
 
-// we match all css variable looking things (including special chars within square brackets
+// we match all css variable looking things (including special chars within curly brackets
 // for arbitrary selectors) and determine whether they're a tokenami value/property
 // based on tokenami config. we purposefully don't match `var(...)` for values because we want
 // consumers to be able to pass a generated stylesheet to `includes` to support external design
-// system packages (thanks chat gpt)
-const CSS_VARIABLE_REGEX = /--(?:[\w-]+|\[[^\[\]]*(?:\[[^\[\]]*\][^\[\]]*)*\])+/g;
+// system packages (thanks chat gpt for the regex).
+const CSS_VARIABLE_REGEX = /--(?:[\w-]+|\{[^\{\}]*\})+/g;
 
 function matchTokens(content: string, theme: Tokenami.Config['theme']) {
   const matches = Array.from(content.match(CSS_VARIABLE_REGEX) || []);

--- a/packages/dev/src/declarations.ts
+++ b/packages/dev/src/declarations.ts
@@ -14,8 +14,8 @@ type PropertyConfig = TokenamiFinalConfig['properties'];
 type SelectorKey = keyof TokenamiFinalConfig['selectors'];
 type ResponsiveKey = keyof TokenamiFinalConfig['responsive'];
 type ResponsiveSelectorKey = `${ResponsiveKey}_${SelectorKey}`;
-type ResponsiveArbitrarySelectorKey = `${ResponsiveKey}_[${string}]`;
-type ArbitrarySelectorKey = `[${string}]`;
+type ResponsiveArbitrarySelectorKey = `${ResponsiveKey}_{${string}}`;
+type ArbitrarySelectorKey = `{${string}}`;
 type VariantKey =
   | ResponsiveKey
   | SelectorKey

--- a/packages/dev/src/declarations.ts
+++ b/packages/dev/src/declarations.ts
@@ -14,6 +14,14 @@ type PropertyConfig = TokenamiFinalConfig['properties'];
 type SelectorKey = keyof TokenamiFinalConfig['selectors'];
 type ResponsiveKey = keyof TokenamiFinalConfig['responsive'];
 type ResponsiveSelectorKey = `${ResponsiveKey}_${SelectorKey}`;
+type ResponsiveArbitrarySelectorKey = `${ResponsiveKey}_[${string}]`;
+type ArbitrarySelectorKey = `[${string}]`;
+type VariantKey =
+  | ResponsiveKey
+  | SelectorKey
+  | ResponsiveSelectorKey
+  | ArbitrarySelectorKey
+  | ResponsiveArbitrarySelectorKey;
 
 type Theme = ThemeConfig extends Tokenami.ThemeModes<infer T> ? T : ThemeConfig;
 
@@ -38,7 +46,7 @@ type AliasedProperty<P> = {
 type VariantProperty<P extends string> =
   | Tokenami.TokenProperty<P>
   | (TokenamiFinalConfig['CI'] extends true
-      ? Tokenami.VariantProperty<P, ResponsiveKey | SelectorKey | ResponsiveSelectorKey>
+      ? Tokenami.VariantProperty<P, VariantKey>
       : Tokenami.VariantProperty<P, string>);
 
 type TokenValue<P> = P extends keyof PropertyConfig

--- a/packages/dev/src/sheet.ts
+++ b/packages/dev/src/sheet.ts
@@ -3,6 +3,7 @@ import { stringify } from '@stitches/stringify';
 import * as lightning from 'lightningcss';
 import * as utils from './utils';
 import { supportedProperties, supportedLogicalProperties } from './supports';
+import * as log from './log';
 
 const UNUSED_LAYERS_REGEX = /\n\s*@layer[-\w\s,]+;/g;
 const DEFAULT_SELECTOR = '[style]';
@@ -123,14 +124,19 @@ function generate(params: {
     }
   `;
 
-  const transformed = lightning.transform({
-    code: Buffer.from(sheet),
-    filename: params.output,
-    minify: params.minify,
-    targets: params.targets,
-  });
+  try {
+    const transformed = lightning.transform({
+      code: Buffer.from(sheet),
+      filename: params.output,
+      minify: params.minify,
+      targets: params.targets,
+    });
 
-  return transformed.code.toString().replace(UNUSED_LAYERS_REGEX, '');
+    return transformed.code.toString().replace(UNUSED_LAYERS_REGEX, '');
+  } catch (e) {
+    log.debug(`Skipped generate style with ${e}`);
+    return '';
+  }
 }
 
 /* -------------------------------------------------------------------------------------------------

--- a/packages/dev/src/sheet.ts
+++ b/packages/dev/src/sheet.ts
@@ -71,9 +71,10 @@ function generate(params: {
         const selectors = getSelectorsFromConfig(config.selector, params.config);
         const shouldInherit = selectors.some(isCombinatorSelector);
         const responsiveSelectors = [responsive, ...selectors].filter(Boolean) as string[];
-        const variantProperty = Tokenami.variantProperty(config.variant, cssProperty);
         const hashedProperty = hashVariantProperty(config.variant, cssProperty);
+        const variantProperty = Tokenami.variantProperty(config.variant, cssProperty);
         const toggleProperty = Tokenami.tokenProperty(config.variant);
+
         const toggleDeclaration = `${hashedProperty}: var(${toggleProperty}) var(${variantProperty});`;
         const layer = `${isLogical ? LAYERS.SELECTORS_LOGICAL : LAYERS.SELECTORS}${layerCount}`;
         const declaration = `${cssProperty}: ${variantValue};`;
@@ -293,8 +294,10 @@ function getSelectorsFromConfig(
   propertySelector: PropertyConfig['selector'],
   tokenamiConfig: Tokenami.Config
 ) {
-  const selector = propertySelector && tokenamiConfig.selectors?.[propertySelector];
-  const selectors = Array.isArray(selector) ? selector : selector ? [selector] : ['&'];
+  const arbitrarySelector = Tokenami.getArbitrarySelector(propertySelector);
+  const configSelector = propertySelector && tokenamiConfig.selectors?.[propertySelector];
+  const selector = arbitrarySelector?.replace(/_/g, ' ') || configSelector;
+  const selectors = selector ? (Array.isArray(selector) ? selector : [selector]) : ['&'];
   const isSelectionVariant = selectors.includes('&::selection');
   return selectors.map((selector) => {
     // revert-layer for ::selection doesn't work: https://codepen.io/jjenzz/pen/LYvOydB

--- a/packages/dev/src/sheet.ts
+++ b/packages/dev/src/sheet.ts
@@ -73,8 +73,8 @@ function generate(params: {
         const shouldInherit = selectors.some(isCombinatorSelector);
         const responsiveSelectors = [responsive, ...selectors].filter(Boolean) as string[];
         const hashedProperty = hashVariantProperty(config.variant, cssProperty);
-        const variantProperty = Tokenami.variantProperty(config.variant, cssProperty);
-        const toggleProperty = Tokenami.tokenProperty(config.variant);
+        const variantProperty = Tokenami.parsedVariantProperty(config.variant, cssProperty);
+        const toggleProperty = Tokenami.parsedTokenProperty(config.variant);
 
         const toggleDeclaration = `${hashedProperty}: var(${toggleProperty}) var(${variantProperty});`;
         const layer = `${isLogical ? LAYERS.SELECTORS_LOGICAL : LAYERS.SELECTORS}${layerCount}`;
@@ -135,7 +135,7 @@ function generate(params: {
     return transformed.code.toString().replace(UNUSED_LAYERS_REGEX, '');
   } catch (e) {
     log.debug(`Skipped generate style with ${e}`);
-    return '';
+    return `${e}`;
   }
 }
 
@@ -169,7 +169,7 @@ function getPropertyConfigs(
     const order = responsiveOrder + selectorOrder;
 
     properties.forEach((cssProperty) => {
-      const tokenProperty = Tokenami.tokenProperty(cssProperty);
+      const tokenProperty = Tokenami.parsedTokenProperty(cssProperty);
       const currentConfigs = propertyConfigs.get(cssProperty as any) || [];
       const nextConfig = { ...parts, tokenProperty, order };
       propertyConfigs.set(cssProperty, [...currentConfigs, nextConfig]);

--- a/packages/ts-plugin/src/index.ts
+++ b/packages/ts-plugin/src/index.ts
@@ -261,7 +261,10 @@ function init(modules: { typescript: typeof tslib }) {
 
         if (variants.length && !parts && !isArbitrarySelector) {
           const selector = variants.join('_');
-          const message = `Tokenami properties may only specify known selectors, and '${selector}' does not exist.`;
+          const isEmptyArbitrarySelector = variants.includes('[]');
+          const message = `Tokenami properties may only specify known selectors, and '${selector}' does not exist.${
+            isEmptyArbitrarySelector ? ` Add an arbitrary selector or remove '${selector}'.` : ''
+          }`;
           diagnostics.push({
             file: sourceFile,
             start: node.getStart(),

--- a/packages/ts-plugin/src/index.ts
+++ b/packages/ts-plugin/src/index.ts
@@ -29,7 +29,7 @@ function init(modules: { typescript: typeof tslib }) {
   ): tslib.CompletionEntry[] {
     const configResponsiveEntries = Object.entries(config.responsive || {});
     const configSelectorEntries = Object.entries(config.selectors || {});
-    const allSelectorEntries = configSelectorEntries.concat([['[]', '']]);
+    const allSelectorEntries = configSelectorEntries.concat([['{}', '']]);
     const configAliasProperties = Object.keys(config.aliases || {});
 
     return [...Tokenami.supportedProperties, ...configAliasProperties].flatMap((property) => {
@@ -60,13 +60,13 @@ function init(modules: { typescript: typeof tslib }) {
       const name = removeSpecialCharEscaping(`${quote}${tokenProperty}${quote}`);
       const kind = tslib.ScriptElementKind.memberVariableElement;
       const kindModifiers = tslib.ScriptElementKindModifier.optionalModifier;
-      const isArbitrary = name.includes('[]');
+      const isArbitrary = name.includes('{}');
       updateEntryDetailsConfig({ name, kind, kindModifiers, value });
 
       if (isArbitrary) {
         // we prepend 1 to sort arbitrary values after non-arbitrary ones
         const sortText = `1${name}`;
-        const insertText = name.replace('[]', '[${1}]');
+        const insertText = name.replace('{}', '{${1}}');
         return { name, kind, kindModifiers, sortText, insertText, isSnippet: true };
       }
 
@@ -261,7 +261,7 @@ function init(modules: { typescript: typeof tslib }) {
 
         if (variants.length && !parts && !isArbitrarySelector) {
           const selector = variants.join('_');
-          const isEmptyArbitrarySelector = variants.includes('[]');
+          const isEmptyArbitrarySelector = variants.includes('{}');
           const message = `Tokenami properties may only specify known selectors, and '${selector}' does not exist.${
             isEmptyArbitrarySelector ? ` Add an arbitrary selector or remove '${selector}'.` : ''
           }`;


### PR DESCRIPTION
# Summary

adds support for arbitrary selectors using curly braces.

```tsx
<div
  style={css({
    '--{&:hover}_color': 'var(--color_primary)',
    '--{&:has(:focus)}_border-color': 'var(--color_highlight)',
    '--{&:[data-state=open]}_border-color': 'var(--color_primary)',
    '--md_{&:hover}_color': 'var(--color_secondary)',
  })}
/>
```

if consumers are using a framework that auto-escapes style strings (e.g. vite) then there is a new `escapeSpecialChars` option that can be passed to `createCss` to switch off tokenami's built-in escaping and hand-off to the framework instead. otherwise, the styles will be double-escaped and won't match the generated stylesheet.

Closes #248 

https://github.com/tokenami/tokenami/assets/175330/d65c83e6-7b9f-485a-b7c9-1a572bb3a85f

## Change Type

<!-- Please indicate the type of change this is -->

- [ ] `documentation`
- [ ] `patch`
- [x] `minor`
- [ ] `major`

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.0.53--canary.283.9326594319.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @tokenami/config@0.0.53--canary.283.9326594319.0
  npm install @tokenami/css@0.0.53--canary.283.9326594319.0
  npm install @tokenami/dev@0.0.53--canary.283.9326594319.0
  npm install @tokenami/ts-plugin@0.0.53--canary.283.9326594319.0
  # or 
  yarn add @tokenami/config@0.0.53--canary.283.9326594319.0
  yarn add @tokenami/css@0.0.53--canary.283.9326594319.0
  yarn add @tokenami/dev@0.0.53--canary.283.9326594319.0
  yarn add @tokenami/ts-plugin@0.0.53--canary.283.9326594319.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
