### PR TITLE
add selector support to custom properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -604,22 +604,20 @@ With this configuration, passing `var(--container_half)` to a `content` property
 
 ### Map custom properties to theme
 
-Tokenami allows custom CSS properties using the triple dash syntax (`---custom-property`). If you'd like to ensure these properties only accept token values from your theme, add them to the `properties` config.
-
-This helps you create a configurable design system. For example, you can create `---gradient-from` and `---gradient-to` properties that accept color tokens to make reusable gradients:
+Tokenami allows custom properties in the `properties` config. This helps to create a configurable design system. For example, you can create `--gradient-from` and `--gradient-to` properties that accept color tokens to make reusable gradients:
 
 ```tsx
 module.exports = createConfig({
   // ...
   properties: {
     ...defaultConfig.properties,
-    '---gradient-from': ['color'],
-    '---gradient-to': ['color'],
+    'gradient-from': ['color'],
+    'gradient-to': ['color'],
   },
 });
 ```
 
-Then use the properties in your theme:
+And use the properties in your theme:
 
 ```tsx
 module.exports = createConfig({
@@ -630,24 +628,75 @@ module.exports = createConfig({
     },
     surface: {
       'radial-gradient':
-        'radial-gradient(circle at top, var(---gradient-from), var(---gradient-to) 80%)',
+        'radial-gradient(circle at top, var(--gradient-from), var(--gradient-to) 80%)',
     },
   },
   // ...
 });
 ```
 
-You can then set different gradient stops when applying the gradient, and intellisense will suggest colors from your theme.
+Now you can set different gradient stops when applying the gradient, and intellisense will suggest colours from your theme.
 
 ```tsx
 <div
   style={css({
-    '---gradient-from': 'var(--color_primary)',
-    '---gradient-to': 'var(--color_secondary)',
+    '--gradient-from': 'var(--color_primary)',
+    '--gradient-to': 'var(--color_secondary)',
     '--background': 'var(--surface_radial-gradient)',
   })}
 />
 ```
+
+#### CSS limitations
+
+Theme values containing custom properties are not applied to theme selectors in the generated stylesheet. Tokenami [must apply them to each element](https://codepen.io/jjenzz/pen/eYayMWo) to ensure custom properties are inherited from the element's style attribute. This means theme modes cannot mix custom properties with differing hardcoded values/variables. For example:
+
+```tsx
+// ❌
+{
+  light: {
+    surface: {
+      gradient: 'linear-gradient(to right, red, var(--surface-to))';
+    }
+  }
+  dark: {
+    surface: {
+      gradient: 'linear-gradient(to right, blue, var(--surface-to))';
+    }
+  }
+}
+```
+
+Instead, use matching custom properties and then use custom selectors to apply the different stops based on the theme mode:
+
+```tsx
+// ✅
+{
+  light: {
+    surface: {
+      gradient: 'linear-gradient(to right, var(--surface-from), var(--surface-to))';
+    }
+  }
+  dark: {
+    surface: {
+      gradient: 'linear-gradient(to right, var(--surface-from), var(--surface-to))';
+    }
+  }
+}
+```
+
+```tsx
+<div
+  style={css({
+    '--light_surface-from': 'var(--color_white)',
+    '--dark_surface-from': 'var(--color_black)',
+    '--surface-to': 'var(--color_primary)',
+    '--background': 'var(--surface_gradient)',
+  })}
+/>
+```
+
+This will ensure `--surface-from` is set to `var(--color_white)` in the light theme and `var(--color_black)` in the dark theme.
 
 ### Browserslist
 

--- a/examples/remix/public/tokenami.css
+++ b/examples/remix/public/tokenami.css
@@ -39,10 +39,6 @@ body {
     --size_screen-h: 100vh;
   }
 
-  [style] {
-    --border_thin: 1px solid var(--color_slate-700);
-  }
-
   .theme-dark {
     --_grid: .25rem;
     --anim_wiggle: wiggle 1s ease-in-out infinite;

--- a/packages/config/src/common.ts
+++ b/packages/config/src/common.ts
@@ -153,7 +153,7 @@ function getTokenPropertyParts(tokenProperty: TokenProperty, config: Config): Pr
   const [firstVariant, secondVariant] = variants;
   const firstSelector = getValidSelector(firstVariant, config);
   const secondSelector = getValidSelector(secondVariant, config);
-  const responsive = config.responsive?.[firstVariant!] && firstVariant;
+  const responsive = getValidResponsive(firstVariant, config);
   const selector = firstSelector || secondSelector;
   const validVariant = [responsive, selector].filter(Boolean).join('_');
   const variantProp = variantProperty(validVariant, alias);
@@ -167,7 +167,18 @@ function getTokenPropertyParts(tokenProperty: TokenProperty, config: Config): Pr
 
 function getValidSelector(selector: string | undefined, config: Config) {
   if (!selector) return;
-  return (getArbitrarySelector(selector) || config.selectors?.[selector!]) && selector;
+  const configSelector = config.selectors?.[selector!];
+  return (getArbitrarySelector(selector) || configSelector) && selector;
+}
+
+/* -------------------------------------------------------------------------------------------------
+ * getValidResponsive
+ * -----------------------------------------------------------------------------------------------*/
+
+function getValidResponsive(responsive: string | undefined, config: Config) {
+  if (!responsive) return;
+  const configResponsive = config.responsive?.[responsive!];
+  return configResponsive && responsive;
 }
 
 /* -------------------------------------------------------------------------------------------------

--- a/packages/config/src/config.ts
+++ b/packages/config/src/config.ts
@@ -47,7 +47,7 @@ interface Config {
   aliases?: Aliases;
   themeSelector?: (mode: string) => string;
   theme: ThemeConfig;
-  properties?: Partial<Record<CSSProperty | `---${string}`, PropertiesOptions>>;
+  properties?: Partial<Record<CSSProperty | (string & {}), PropertiesOptions>>;
 }
 
 const defaultConfig = {

--- a/packages/dev/src/declarations.ts
+++ b/packages/dev/src/declarations.ts
@@ -68,7 +68,11 @@ type TokensByThemeKey = { [key: string]: never } & {
 };
 
 type CustomProperty = Omit<PropertyConfig, keyof Tokenami.CSSProperties>;
-type CustomProperties = { [K in keyof CustomProperty]?: TokenValue<K> };
+type CustomProperties = {
+  [K in VariantProperty<keyof CustomProperty>]?: K extends VariantProperty<infer P>
+    ? TokenValue<P>
+    : never;
+};
 
 /**
  * -------------------------------------------------------------------------


### PR DESCRIPTION
# Summary

Closes #303

adds support for selectors to custom properties, e.g. `--dark_surface-from`. 

this code isn't the best for now but it works... 

> Make it work, then make it good

;)

## Release Notes

please remove the triple-dash prefix for any custom properties you have defined in the `properties` object of your `tokenami.config` and update usage with a double-dash prefix. custom properties now behave like regular properties to enable selector support.

## Change Type

<!-- Please indicate the type of change this is -->

- [ ] `documentation`
- [ ] `patch`
- [ ] `minor`
- [x] `major`

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.0.58--canary.305.9734436082.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @tokenami/config@0.0.58--canary.305.9734436082.0
  npm install @tokenami/css@0.0.58--canary.305.9734436082.0
  npm install @tokenami/dev@0.0.58--canary.305.9734436082.0
  npm install @tokenami/ts-plugin@0.0.58--canary.305.9734436082.0
  # or 
  yarn add @tokenami/config@0.0.58--canary.305.9734436082.0
  yarn add @tokenami/css@0.0.58--canary.305.9734436082.0
  yarn add @tokenami/dev@0.0.58--canary.305.9734436082.0
  yarn add @tokenami/ts-plugin@0.0.58--canary.305.9734436082.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
