### PR TITLE
add ts plugin colour swatches for custom colour theme keys

### DIFF
--- a/examples/design-system/.tokenami/tokenami.config.ts
+++ b/examples/design-system/.tokenami/tokenami.config.ts
@@ -10,6 +10,19 @@ const colorPalette = createPalette('var(--color-opacity, 1)');
 const shadowPalette = createPalette('var(--shadow-opacity, 1)');
 
 const theme = {
+  alpha: {
+    '0': '0',
+    '10': '0.1',
+    '20': '0.2',
+    '30': '0.3',
+    '40': '0.4',
+    '50': '0.5',
+    '60': '0.6',
+    '70': '0.7',
+    '80': '0.8',
+    '90': '0.9',
+    '100': '1',
+  },
   color: {
     ...colorPalette,
     primary: colorPalette['slate-100'],
@@ -112,7 +125,7 @@ export default createConfig({
   },
   properties: {
     ...defaultConfig.properties,
-    'color-opacity': ['color'],
-    'shadow-opacity': ['shadow'],
+    'color-opacity': ['alpha'],
+    'shadow-opacity': ['alpha'],
   },
 });

--- a/examples/design-system/.tokenami/tokenami.config.ts
+++ b/examples/design-system/.tokenami/tokenami.config.ts
@@ -1,17 +1,26 @@
 import { type Config, createConfig, defaultConfig } from '@tokenami/css';
 
-const palette = {
-  'slate-100': 'rgba(241 245 249 / var(--color-opacity, 1))',
-  'slate-700': 'rgba(51 65 85 / var(--color-opacity, 1))',
-  'sky-500': 'rgba(14 165 233 / var(--color-opacity, 1))',
-};
+const createPalette = (opacity: string) => ({
+  'slate-100': `rgba(241 245 249 / ${opacity})`,
+  'slate-700': `rgba(51 65 85 / ${opacity})`,
+  'sky-500': `rgba(14 165 233 / ${opacity})`,
+});
+
+const colorPalette = createPalette('var(--color-opacity, 1)');
+const shadowPalette = createPalette('var(--shadow-opacity, 1)');
 
 const theme = {
   color: {
-    ...palette,
-    primary: palette['slate-100'],
-    secondary: palette['slate-700'],
-    tertiary: palette['sky-500'],
+    ...colorPalette,
+    primary: colorPalette['slate-100'],
+    secondary: colorPalette['slate-700'],
+    tertiary: colorPalette['sky-500'],
+  },
+  shadow: {
+    ...shadowPalette,
+    primary: shadowPalette['slate-100'],
+    secondary: shadowPalette['slate-700'],
+    tertiary: shadowPalette['sky-500'],
   },
   anim: {
     wiggle: 'wiggle 1s ease-in-out infinite',
@@ -60,10 +69,16 @@ export default createConfig({
       dark: {
         ...theme,
         color: {
-          ...theme.color,
-          primary: palette['sky-500'],
-          secondary: palette['slate-100'],
-          tertiary: palette['slate-700'],
+          ...colorPalette,
+          primary: colorPalette['sky-500'],
+          secondary: colorPalette['slate-100'],
+          tertiary: colorPalette['slate-700'],
+        },
+        shadow: {
+          ...shadowPalette,
+          primary: shadowPalette['sky-500'],
+          secondary: shadowPalette['slate-100'],
+          tertiary: shadowPalette['slate-700'],
         },
       },
     },
@@ -94,5 +109,10 @@ export default createConfig({
     pr: ['padding-right'],
     pb: ['padding-bottom'],
     pl: ['padding-left'],
+  },
+  properties: {
+    ...defaultConfig.properties,
+    'color-opacity': ['color'],
+    'shadow-opacity': ['shadow'],
   },
 });

--- a/examples/design-system/src/button/button.tsx
+++ b/examples/design-system/src/button/button.tsx
@@ -32,6 +32,9 @@ const button = css.compose({
   '--hover_color': 'var(---,white)',
   '--hover_animation': 'var(--anim_wiggle)',
   '--{&:focus:hover}_background-color': 'var(---, red)',
+  '--color-opacity': 'var(--alpha_30)',
+  '--md_color-opacity': 'var(--alpha_80)',
+  '--hover_color-opacity': 'var(--alpha_100)',
 
   responsiveVariants: {
     size: {

--- a/examples/design-system/src/tokenami.css
+++ b/examples/design-system/src/tokenami.css
@@ -24,20 +24,20 @@ body {
     --_grid: .25rem;
     --anim_wiggle: wiggle 1s ease-in-out infinite;
     --border_thin: 1px solid var(--color_slate-700);
-    --color_slate-700: rgba(51 65 85 / var(--color-opacity, 1));
-    --color_primary: rgba(241 245 249 / var(--color-opacity, 1));
-    --color_secondary: rgba(51 65 85 / var(--color-opacity, 1));
     --font_sans: sans-serif;
     --radii_rounded: 10px;
+  }
+
+  [style] {
+    --color_slate-700: rgba(51 65 85 / var(--_color-opacity, 1));
+    --color_primary: rgba(14 165 233 / var(--_color-opacity, 1));
+    --color_secondary: rgba(241 245 249 / var(--_color-opacity, 1));
   }
 
   .theme-dark {
     --_grid: .25rem;
     --anim_wiggle: wiggle 1s ease-in-out infinite;
     --border_thin: 1px solid var(--color_slate-700);
-    --color_slate-700: rgba(51 65 85 / var(--color-opacity, 1));
-    --color_primary: rgba(14 165 233 / var(--color-opacity, 1));
-    --color_secondary: rgba(241 245 249 / var(--color-opacity, 1));
     --font_sans: sans-serif;
     --radii_rounded: 10px;
   }

--- a/examples/design-system/src/tokenami.css
+++ b/examples/design-system/src/tokenami.css
@@ -22,6 +22,9 @@ body {
 
   .theme-light {
     --_grid: .25rem;
+    --alpha_100: 1;
+    --alpha_30: .3;
+    --alpha_80: .8;
     --anim_wiggle: wiggle 1s ease-in-out infinite;
     --border_thin: 1px solid var(--color_slate-700);
     --font_sans: sans-serif;
@@ -36,6 +39,9 @@ body {
 
   .theme-dark {
     --_grid: .25rem;
+    --alpha_100: 1;
+    --alpha_30: .3;
+    --alpha_80: .8;
     --anim_wiggle: wiggle 1s ease-in-out infinite;
     --border_thin: 1px solid var(--color_slate-700);
     --font_sans: sans-serif;
@@ -58,8 +64,11 @@ body {
     --height: initial;
     --transition: initial;
     --hover_animation: initial;
-    --font-size: initial;
+    --color-opacity: initial;
     --md: initial;
+    --md_color-opacity: initial;
+    --hover_color-opacity: initial;
+    --font-size: initial;
     --md_font-size: initial;
     --lg: initial;
     --lg_font-size: initial;
@@ -77,6 +86,7 @@ body {
       width: var(--width, revert-layer);
       height: var(--height, revert-layer);
       transition: var(--transition, revert-layer);
+      --_color-opacity: var(--color-opacity, revert-layer);
     }
   }
 
@@ -95,6 +105,9 @@ body {
       --_853it7: var(--hover) var(--hover_color);
       animation: var(--_1upk2ho, revert-layer);
       --_1upk2ho: var(--hover) var(--hover_animation);
+      --_color-opacity: var(--_hgg3v5, var(--_r6a24m, var(--color-opacity)));
+      --_r6a24m: var(--md) var(--md_color-opacity);
+      --_hgg3v5: var(--hover) var(--hover_color-opacity);
     }
   }
 

--- a/examples/remix/public/tokenami.css
+++ b/examples/remix/public/tokenami.css
@@ -22,6 +22,9 @@ body {
 
   .theme-light {
     --_grid: .25rem;
+    --alpha_100: 1;
+    --alpha_30: .3;
+    --alpha_80: .8;
     --anim_wiggle: wiggle 1s ease-in-out infinite;
     --border_thin: 1px solid var(--color_slate-700);
     --font_sans: sans-serif;
@@ -44,6 +47,9 @@ body {
 
   .theme-dark {
     --_grid: .25rem;
+    --alpha_100: 1;
+    --alpha_30: .3;
+    --alpha_80: .8;
     --anim_wiggle: wiggle 1s ease-in-out infinite;
     --border_thin: 1px solid var(--color_slate-700);
     --font_sans: sans-serif;
@@ -57,9 +63,12 @@ body {
   }
 
   [style] {
-    --_color-opacity: initial;
-    --background-color: initial;
+    --color-opacity: initial;
+    --md: initial;
+    --md_color-opacity: initial;
     --hover: initial;
+    --hover_color-opacity: initial;
+    --background-color: initial;
     --hover_background-color: initial;
     --\{\&\;focus\;hover\}: initial;
     --\{\&\;focus\;hover\}_background-color: initial;
@@ -72,7 +81,6 @@ body {
     --border: initial;
     --border-bottom: initial;
     --border-radius: initial;
-    --md: initial;
     --md_border-radius: initial;
     --lg: initial;
     --lg_border-radius: initial;
@@ -206,6 +214,9 @@ body {
 
   @layer tks1 {
     [style], [style] > p, [style*="select_"]::selection, [style]:after {
+      --_color-opacity: var(--_hgg3v5, var(--_r6a24m, var(--color-opacity)));
+      --_r6a24m: var(--md) var(--md_color-opacity);
+      --_hgg3v5: var(--hover) var(--hover_color-opacity);
       color: var(--_6grdv7, var(--_hdgn0i, var(--_853it7, revert-layer)));
       --_853it7: var(--hover) var(--hover_color);
       --_hdgn0i: var(--child-para) var(--child-para_color);
@@ -260,6 +271,16 @@ body {
     }
   }
 
+  @media (width >= 700px) {
+    [style] {
+      --md: ;
+    }
+
+    [style]:after {
+      --md_after: ;
+    }
+  }
+
   @media (hover: hover) and (pointer: fine) {
     [style]:hover {
       --hover: ;
@@ -276,16 +297,6 @@ body {
 
   [style]:focus:hover {
     --\{\&\;focus\;hover\}: ;
-  }
-
-  @media (width >= 700px) {
-    [style] {
-      --md: ;
-    }
-
-    [style]:after {
-      --md_after: ;
-    }
   }
 
   @media (width >= 1024px) {

--- a/examples/remix/public/tokenami.css
+++ b/examples/remix/public/tokenami.css
@@ -24,11 +24,6 @@ body {
     --_grid: .25rem;
     --anim_wiggle: wiggle 1s ease-in-out infinite;
     --border_thin: 1px solid var(--color_slate-700);
-    --color_slate-700: rgba(51 65 85 / var(--color-opacity, 1));
-    --color_primary: rgba(241 245 249 / var(--color-opacity, 1));
-    --color_secondary: rgba(51 65 85 / var(--color-opacity, 1));
-    --color_sky-500: rgba(14 165 233 / var(--color-opacity, 1));
-    --color_slate-100: rgba(241 245 249 / var(--color-opacity, 1));
     --font_sans: sans-serif;
     --pet_favourite: "🐶";
     --radii_circle: 9999px;
@@ -39,15 +34,18 @@ body {
     --size_screen-h: 100vh;
   }
 
+  [style] {
+    --color_slate-700: rgba(51 65 85 / var(--_color-opacity, 1));
+    --color_primary: rgba(14 165 233 / var(--_color-opacity, 1));
+    --color_secondary: rgba(241 245 249 / var(--_color-opacity, 1));
+    --color_sky-500: rgba(14 165 233 / var(--_color-opacity, 1));
+    --color_slate-100: rgba(241 245 249 / var(--_color-opacity, 1));
+  }
+
   .theme-dark {
     --_grid: .25rem;
     --anim_wiggle: wiggle 1s ease-in-out infinite;
     --border_thin: 1px solid var(--color_slate-700);
-    --color_slate-700: rgba(51 65 85 / var(--color-opacity, 1));
-    --color_primary: rgba(14 165 233 / var(--color-opacity, 1));
-    --color_secondary: rgba(241 245 249 / var(--color-opacity, 1));
-    --color_sky-500: rgba(14 165 233 / var(--color-opacity, 1));
-    --color_slate-100: rgba(241 245 249 / var(--color-opacity, 1));
     --font_sans: sans-serif;
     --pet_favourite: "🐱";
     --radii_circle: 9999px;
@@ -59,6 +57,7 @@ body {
   }
 
   [style] {
+    --_color-opacity: initial;
     --background-color: initial;
     --hover: initial;
     --hover_background-color: initial;
@@ -144,6 +143,7 @@ body {
 
   @layer tk1 {
     [style] {
+      --_color-opacity: var(--color-opacity, revert-layer);
       color: var(--color, revert-layer);
       border: var(--border, revert-layer);
       border-radius: var(--border-radius, revert-layer);

--- a/packages/dev/src/sheet.ts
+++ b/packages/dev/src/sheet.ts
@@ -81,7 +81,11 @@ function generate(params: {
         const toggleProperty = Tokenami.parsedTokenProperty(config.variant);
         const toggleDeclaration = `${hashedProperty}: var(${toggleProperty}) var(${variantProperty});`;
         const layer = `${isLogical ? LAYERS.SELECTORS_LOGICAL : LAYERS.SELECTORS}${layerCount}`;
-        const declaration = `${propertyPrefix}${cssProperty}: ${variantValue};`;
+        const customPropertyFallback = `var(${Tokenami.tokenProperty(cssProperty)})`;
+        const customPropertyValue = variantValue.replace('revert-layer', customPropertyFallback);
+        const declaration = `${propertyPrefix}${cssProperty}: ${
+          config.isCustom ? customPropertyValue : variantValue
+        };`;
 
         const toggle = responsiveSelectors.reduceRight(
           (declaration, selector) => `${selector} { ${declaration} }`,
@@ -98,10 +102,7 @@ function generate(params: {
         const propertyValue = `var(${config.tokenProperty}, revert-layer)`;
         const declaration = `${DEFAULT_SELECTOR} { ${propertyPrefix}${cssProperty}: ${propertyValue}; }`;
         const layer = `${isLogical ? LAYERS.LOGICAL : LAYERS.BASE}${layerCount}`;
-        const resetProperty = config.isCustom
-          ? config.tokenProperty.replace(Tokenami.tokenProperty(''), CUSTOM_PROP_PREFIX)
-          : config.tokenProperty;
-        styles.reset.add(`${resetProperty}: initial;`);
+        styles.reset.add(`${config.tokenProperty}: initial;`);
         styles.atomic.add(`@layer ${layer} { ${declaration} }`);
       }
     });

--- a/packages/dev/src/sheet.ts
+++ b/packages/dev/src/sheet.ts
@@ -98,7 +98,10 @@ function generate(params: {
         const propertyValue = `var(${config.tokenProperty}, revert-layer)`;
         const declaration = `${DEFAULT_SELECTOR} { ${propertyPrefix}${cssProperty}: ${propertyValue}; }`;
         const layer = `${isLogical ? LAYERS.LOGICAL : LAYERS.BASE}${layerCount}`;
-        styles.reset.add(`${config.tokenProperty}: initial;`);
+        const resetProperty = config.isCustom
+          ? config.tokenProperty.replace(Tokenami.tokenProperty(''), CUSTOM_PROP_PREFIX)
+          : config.tokenProperty;
+        styles.reset.add(`${resetProperty}: initial;`);
         styles.atomic.add(`@layer ${layer} { ${declaration} }`);
       }
     });

--- a/packages/dev/src/sheet.ts
+++ b/packages/dev/src/sheet.ts
@@ -81,6 +81,8 @@ function generate(params: {
         const toggleProperty = Tokenami.parsedTokenProperty(config.variant);
         const toggleDeclaration = `${hashedProperty}: var(${toggleProperty}) var(${variantProperty});`;
         const layer = `${isLogical ? LAYERS.SELECTORS_LOGICAL : LAYERS.SELECTORS}${layerCount}`;
+        // revert-layer doesn't work for custom properties in Safari so we explicitly set the fallback
+        // to the base custom property value for variants
         const customPropertyFallback = `var(${Tokenami.tokenProperty(cssProperty)})`;
         const customPropertyValue = variantValue.replace('revert-layer', customPropertyFallback);
         const declaration = `${propertyPrefix}${cssProperty}: ${

--- a/packages/ts-plugin/src/index.ts
+++ b/packages/ts-plugin/src/index.ts
@@ -178,7 +178,7 @@ function init(modules: { typescript: typeof tslib }) {
     if (!Object.entries(modeValues).length) return entry;
 
     const name = `$${parts.token}`;
-    const kindModifiers = parts.themeKey;
+    const kindModifiers = isColorThemeEntry(modeValues) ? 'color' : parts.themeKey;
     const sortText = '$' + entryName;
     const labelDetails = { detail: '', description: entryName };
     const insertText = entryName;
@@ -435,7 +435,7 @@ function init(modules: { typescript: typeof tslib }) {
         const entries = Object.entries(entryConfig.modeValues);
         const [, firstValue] = entries[0] || [];
 
-        if (entryConfig.themeKey === 'color') {
+        if (isColorThemeEntry(entryConfig.modeValues)) {
           const description = createColorTokenDescription(entryConfig.modeValues);
           const hex = firstValue
             ? convertToHex(replaceCssVarsWithFallback(firstValue))
@@ -481,10 +481,8 @@ function init(modules: { typescript: typeof tslib }) {
       const propertyParts = TokenamiConfig.getTokenPropertyParts(tokenProperty.output, config);
       if (!propertyParts && variants.length) return;
 
-      const parts = TokenamiConfig.getTokenValueParts(tokenValue.output);
       const modeValues = Tokenami.getThemeValuesByThemeMode(tokenValue.output, config.theme);
-      const isColor = parts.themeKey === 'color';
-      const text = isColor
+      const text = isColorThemeEntry(modeValues)
         ? createColorTokenDescription(modeValues)
         : createTokenDescription(modeValues);
 
@@ -540,6 +538,11 @@ function replaceCssVarsWithFallback(value: string) {
   const regex = /var\([\w-_]+,\s*([\w-_]+)\)/g;
   // replace the CSS variables with their fallback values
   return value.replace(regex, (_, fallback) => fallback);
+}
+
+function isColorThemeEntry(modeValues: Record<string, string>) {
+  const firstValue = Object.values(modeValues || {})?.[0];
+  return Boolean(culori.parse(replaceCssVarsWithFallback(firstValue || '')));
 }
 
 export = init;


### PR DESCRIPTION
# Summary

Closes #318

https://github.com/tokenami/tokenami/assets/175330/54ba8712-7d1b-4165-915b-33c997573f75

## Change Type

<!-- Please indicate the type of change this is -->

- [ ] `documentation`
- [ ] `patch`
- [x] `minor`
- [ ] `major`

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.0.59--canary.321.9829587413.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @tokenami/config@0.0.59--canary.321.9829587413.0
  npm install @tokenami/css@0.0.59--canary.321.9829587413.0
  npm install @tokenami/dev@0.0.59--canary.321.9829587413.0
  npm install @tokenami/ts-plugin@0.0.59--canary.321.9829587413.0
  # or 
  yarn add @tokenami/config@0.0.59--canary.321.9829587413.0
  yarn add @tokenami/css@0.0.59--canary.321.9829587413.0
  yarn add @tokenami/dev@0.0.59--canary.321.9829587413.0
  yarn add @tokenami/ts-plugin@0.0.59--canary.321.9829587413.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
