### PR TITLE
add global layer

### DIFF
--- a/packages/dev/src/sheet.ts
+++ b/packages/dev/src/sheet.ts
@@ -111,7 +111,9 @@ function generate(params: {
   });
 
   const sheet = `
-    ${params.config.globalStyles ? stringify(params.config.globalStyles) : ''}
+    @layer global {
+      ${params.config.globalStyles ? stringify(params.config.globalStyles) : ''}
+    }
 
     @layer tokenami {
       ${generateKeyframeRules(tokenValues, params.config)}


### PR DESCRIPTION
# Summary

currently the global styles in a situation like the following would win:

```css
div {
  color: red;
}
@layer tokenami {
  [style] {
    color: blue;
  }
}
```

this lowers the specificity of global styles so tokenami styles can override.

## Change Type

<!-- Please indicate the type of change this is -->

- [ ] `documentation`
- [x] `patch`
- [ ] `minor`
- [ ] `major`
