### PR TITLE
selector support for all custom properties in theme values

### DIFF
--- a/packages/dev/src/sheet.ts
+++ b/packages/dev/src/sheet.ts
@@ -310,14 +310,14 @@ const getPrefixedCustomPropertyValues = (
   themeValue: string,
   properties?: Tokenami.Config['properties']
 ) => {
-  const variables = themeValue.match(/--[\w-_]+/g);
+  const variables = themeValue.match(/\(--[^-][\w-]+/g)?.map((v) => v.replace('(', ''));
   if (!variables) return null;
 
   for (const variable of variables) {
     const tokenProperty = Tokenami.TokenProperty.safeParse(variable);
-    if (!tokenProperty.success) return;
+    if (!tokenProperty.success) continue;
     const parts = Tokenami.getTokenPropertySplit(tokenProperty.output);
-    if (supportedProperties.has(parts.alias as any) || !properties?.[parts.alias]) return;
+    if (supportedProperties.has(parts.alias as any) || !properties?.[parts.alias]) continue;
     const tokenPrefix = Tokenami.tokenProperty('');
     const customPrefixTokenValue = tokenProperty.output.replace(tokenPrefix, CUSTOM_PROP_PREFIX);
     themeValue = themeValue.replace(tokenProperty.output, customPrefixTokenValue);

--- a/packages/ts-plugin/src/index.ts
+++ b/packages/ts-plugin/src/index.ts
@@ -501,7 +501,7 @@ function convertToHex(input: string) {
   try {
     const parsed = culori.parse(input);
     return culori.formatHex8(parsed);
-  } catch (e) {
+  } catch {
     return input;
   }
 }
@@ -541,8 +541,12 @@ function replaceCssVarsWithFallback(value: string) {
 }
 
 function isColorThemeEntry(modeValues: Record<string, string>) {
-  const firstValue = Object.values(modeValues || {})?.[0];
-  return Boolean(culori.parse(replaceCssVarsWithFallback(firstValue || '')));
+  try {
+    const firstValue = Object.values(modeValues || {})?.[0];
+    return Boolean(culori.parse(replaceCssVarsWithFallback(firstValue || '')));
+  } catch {
+    return false;
+  }
 }
 
 export = init;


### PR DESCRIPTION
# Summary

i added some logic previously to add [selector support for custom properties in theme values](https://github.com/tokenami/tokenami/pull/305), but it only added selector support to the first custom property in a theme value. 

this PR enables selectors for all custom properties in a theme value and ensures any triple dash properties are ignored since custom properties from `properties` config must start with a double-dash when authored.

## Change Type

<!-- Please indicate the type of change this is -->

- [ ] `documentation`
- [x] `patch`
- [ ] `minor`
- [ ] `major`
