### PR TITLE
improve ts plugin performance with trie search

### DIFF
--- a/packages/ts-plugin/package.json
+++ b/packages/ts-plugin/package.json
@@ -15,7 +15,8 @@
   },
   "dependencies": {
     "@tokenami/config": "workspace:*",
-    "culori": "^4.0.1"
+    "culori": "^4.0.1",
+    "trie-search": "^2.0.0"
   },
   "devDependencies": {
     "@tokenami/dev": "workspace:*",

--- a/packages/ts-plugin/src/index.ts
+++ b/packages/ts-plugin/src/index.ts
@@ -1,4 +1,5 @@
 import tslib from 'typescript/lib/tsserverlibrary';
+import TrieSearch from 'trie-search';
 import * as culori from 'culori';
 import * as TokenamiConfig from '@tokenami/config';
 import * as Tokenami from '@tokenami/dev';
@@ -18,45 +19,105 @@ function init(modules: { typescript: typeof tslib }) {
   const ts = modules.typescript;
   let entryConfigMap = new Map<string, EntryConfigItem>();
 
-  /* ---------------------------------------------------------------------------------------------
+  /* -------------------------------------------------------------------------------------------------
+   * getAllProperties
+   * -----------------------------------------------------------------------------------------------*/
+
+  function getAllProperties(config: TokenamiConfig.Config) {
+    const configAliasProperties = Object.keys(config.aliases || {});
+    const properties = new Set([
+      ...Tokenami.supportedProperties,
+      ...Object.keys(config.properties || {}),
+      ...configAliasProperties,
+    ]);
+    return Array.from(properties);
+  }
+
+  /* -------------------------------------------------------------------------------------------------
+   * getSelectorEntries
+   * -----------------------------------------------------------------------------------------------*/
+
+  function getSelectorEntries(config: TokenamiConfig.Config) {
+    const configSelectorEntries = Object.entries(config.selectors || {});
+    return configSelectorEntries.concat([['{}', '']]);
+  }
+
+  /* -------------------------------------------------------------------------------------------------
+   * getResponsiveCompletions
+   * -----------------------------------------------------------------------------------------------*/
+
+  function getResponsiveCompletions(
+    config: TokenamiConfig.Config,
+    quote?: string
+  ): tslib.CompletionEntry[] {
+    const configResponsiveEntries = Object.entries(config.responsive || {});
+    const allSelectorEntries = getSelectorEntries(config);
+    const properties = getAllProperties(config);
+
+    return properties.flatMap((property) => {
+      const create = createVariantPropertyEntry(property, quote);
+      return configResponsiveEntries.flatMap(([responsiveSelector, responsiveValue]) => {
+        const responsiveEntry = create([responsiveSelector, responsiveValue]);
+        const combinedEntries = allSelectorEntries.map(([selector, value]) => {
+          const combinedSelector = `${responsiveSelector}_${selector}`;
+          const combinedValue = [responsiveValue].concat(value);
+          return create([combinedSelector, combinedValue]);
+        });
+        return [responsiveEntry, ...combinedEntries];
+      });
+    });
+  }
+
+  /* -------------------------------------------------------------------------------------------------
    * getSelectorCompletions
-   * ---------------------------------------------------------------------------------------------
-   * we pre-compute selector entries to improve performance
-   * -------------------------------------------------------------------------------------------*/
+   * -----------------------------------------------------------------------------------------------*/
 
   function getSelectorCompletions(
     config: TokenamiConfig.Config,
     quote?: string
   ): tslib.CompletionEntry[] {
-    const configResponsiveEntries = Object.entries(config.responsive || {});
-    const configSelectorEntries = Object.entries(config.selectors || {});
-    const allSelectorEntries = configSelectorEntries.concat([['{}', '']]);
-    const configAliasProperties = Object.keys(config.aliases || {});
-    const baseProperties = [...Tokenami.supportedProperties, ...configAliasProperties];
-    const customProperties = Object.keys(config.properties || {}).filter(
-      (property) => !Tokenami.supportedProperties.has(property as any)
-    );
-
-    const processEntries = (create: ReturnType<typeof createVariantPropertyEntry>) => {
-      const responsiveEntries = configResponsiveEntries.flatMap(
-        ([responsiveSelector, responsiveValue]) => {
-          const responsiveEntry = create([responsiveSelector, responsiveValue]);
-          const combinedEntries = allSelectorEntries.map(([selector, value]) => {
-            const combinedSelector = `${responsiveSelector}_${selector}`;
-            const combinedValue = [responsiveValue].concat(value);
-            return create([combinedSelector, combinedValue]);
-          });
-          return [responsiveEntry, ...combinedEntries];
-        }
-      );
-      const selectorEntries = allSelectorEntries.map(create);
-      return [...responsiveEntries, ...selectorEntries];
-    };
-
-    return [...baseProperties, ...customProperties].flatMap((property) => {
-      return processEntries(createVariantPropertyEntry(property, quote));
+    const allSelectorEntries = getSelectorEntries(config);
+    const properties = getAllProperties(config);
+    return properties.flatMap((property) => {
+      const create = createVariantPropertyEntry(property, quote);
+      return allSelectorEntries.map(create);
     });
   }
+
+  /* -------------------------------------------------------------------------------------------------
+   * createSelectorTries
+   * -----------------------------------------------------------------------------------------------*/
+
+  const createSelectorTries = (config: TokenamiConfig.Config) => {
+    const responsiveCompletions = getResponsiveCompletions(config);
+    const selectorCompletions = getSelectorCompletions(config);
+    const quotedResponsiveCompletions = getResponsiveCompletions(config, '"');
+    const quotedSelectorCompletions = getSelectorCompletions(config, '"');
+    const completions = [...responsiveCompletions, ...selectorCompletions];
+    const quotedCompletions = [...quotedResponsiveCompletions, ...quotedSelectorCompletions];
+    return {
+      unquoted: createCompletionEntriesTrie(completions, { min: 2 }),
+      quoted: createCompletionEntriesTrie(quotedCompletions, { min: 2 }),
+    };
+  };
+
+  /* -------------------------------------------------------------------------------------------------
+   * createCompletionEntriesTrie
+   * -----------------------------------------------------------------------------------------------*/
+
+  const createCompletionEntriesTrie = (
+    items: tslib.CompletionEntry[],
+    opts?: { min: number }
+  ): TrieSearch<tslib.CompletionEntry> => {
+    const trie = new TrieSearch<tslib.CompletionEntry>('sortText', {
+      splitOnRegEx: /\$/g,
+      expandRegexes: [],
+      min: opts?.min ?? 1,
+    });
+
+    trie.addAll(items);
+    return trie;
+  };
 
   /* ---------------------------------------------------------------------------------------------
    * createVariantPropertyEntry
@@ -81,13 +142,21 @@ function init(modules: { typescript: typeof tslib }) {
     updateEntryDetailsConfig({ name, kind, kindModifiers, value });
 
     if (isArbitrary) {
-      // we prepend 1 to sort arbitrary values after non-arbitrary ones
-      const sortText = `1${name}`;
+      const sortText = getSortText(name);
       const insertText = name.replace('{}', '{${1}}');
       return { name, kind, kindModifiers, sortText, insertText, isSnippet: true };
     }
 
-    return { name, kind, kindModifiers, sortText: `0${name}`, insertText: name };
+    return { name, kind, kindModifiers, sortText: `$${getSortText(name)}`, insertText: name };
+  };
+
+  /* -------------------------------------------------------------------------------------------------
+   * getSortText
+   * -----------------------------------------------------------------------------------------------*/
+
+  const getSortText = (name: string) => {
+    const regex = new RegExp(`['"_]|${TokenamiConfig.tokenProperty('')}`, 'g');
+    return `$${name.replace(regex, '')}`;
   };
 
   /* -----------------------------------------------------------------------------------------------
@@ -119,6 +188,22 @@ function init(modules: { typescript: typeof tslib }) {
     }
     return find(sourceFile);
   }
+
+  /* -------------------------------------------------------------------------------------------------
+   * getPropertyNameAtPosition
+   * -----------------------------------------------------------------------------------------------*/
+
+  const getPropertyNameAtPosition = (node: tslib.Node, position: number) => {
+    if (ts.isStringLiteral(node)) return node.getText();
+    if (!ts.isObjectLiteralExpression(node)) return;
+    for (const property of node.properties) {
+      const start = property.getStart();
+      const end = property.getEnd();
+      if (start <= position && position <= end) {
+        return property.getText();
+      }
+    }
+  };
 
   /* -----------------------------------------------------------------------------------------------
    * createTextSpanFromNode
@@ -155,10 +240,8 @@ function init(modules: { typescript: typeof tslib }) {
   function transformTokenPropertyEntry(entry: tslib.CompletionEntry): tslib.CompletionEntry | null {
     const property = TokenamiConfig.TokenProperty.safeParse(entry.name);
     if (!property.success) return null;
-    // we want known token properties to come before custom ones in sort order
-    const sortText = entry.name.startsWith('---') ? '$' + entry.name : '$$' + entry.name;
-    const name = entry.name;
-    return { ...entry, name, sortText, insertText: name };
+    const sortText = getSortText(entry.name);
+    return { ...entry, sortText, insertText: entry.name };
   }
 
   /* ---------------------------------------------------------------------------------------------
@@ -179,7 +262,7 @@ function init(modules: { typescript: typeof tslib }) {
 
     const name = `$${parts.token}`;
     const kindModifiers = isColorThemeEntry(modeValues) ? 'color' : parts.themeKey;
-    const sortText = '$' + entryName;
+    const sortText = getSortText(entryName);
     const labelDetails = { detail: '', description: entryName };
     const insertText = entryName;
     const nextEntry = { ...entry, name, sortText, kindModifiers, insertText, labelDetails };
@@ -211,10 +294,8 @@ function init(modules: { typescript: typeof tslib }) {
     }
 
     let config = Tokenami.getConfigAtPath(configPath);
-    let selectorCompletions = {
-      unquoted: getSelectorCompletions(config),
-      quoted: getSelectorCompletions(config, '"'),
-    };
+    // pre-compute selector entries to improve performance
+    let selectorCompletions = createSelectorTries(config);
 
     logger.info(`Tokenami:: Watching config at ${configPath}`);
     ts.sys.watchFile?.(configPath, (_, eventKind: tslib.FileWatcherEventKind) => {
@@ -223,10 +304,7 @@ function init(modules: { typescript: typeof tslib }) {
         try {
           config = Tokenami.getReloadedConfigAtPath(configPath);
           info.project.refreshDiagnostics();
-          selectorCompletions = {
-            unquoted: getSelectorCompletions(config),
-            quoted: getSelectorCompletions(config, '"'),
-          };
+          selectorCompletions = createSelectorTries(config);
         } catch (e) {
           logger.info(`Tokenami:: Skipped change to ${configPath} with ${e}`);
         }
@@ -368,7 +446,7 @@ function init(modules: { typescript: typeof tslib }) {
       const original = info.languageService.getCompletionsAtPosition(fileName, position, options);
       const program = info.languageService.getProgram();
       const sourceFile = program?.getSourceFile(fileName);
-      if (!original || !sourceFile) return original;
+      if (!original || !sourceFile) return;
 
       const isTokenPropertyEntries = original.entries.some(
         (entry) => TokenamiConfig.TokenProperty.safeParse(entry.name).success
@@ -378,21 +456,30 @@ function init(modules: { typescript: typeof tslib }) {
       );
 
       if (isTokenValueEntries) {
-        original.entries = original.entries.map((entry) => {
-          return transformTokenValueEntry(entry, config);
-        });
+        original.entries = original.entries.map((entry) => transformTokenValueEntry(entry, config));
       } else if (isTokenPropertyEntries) {
-        const isQuoted = Boolean(original.entries[0]?.name.match(/^"/));
-        original.entries = [
-          ...original.entries.flatMap((entry) => {
-            const transformedEntry = transformTokenPropertyEntry(entry);
-            return transformedEntry ? [transformedEntry] : [];
-          }),
-          ...(isQuoted ? selectorCompletions.quoted : selectorCompletions.unquoted),
-        ];
+        const node = findNodeAtPosition(sourceFile, position);
+        const property = node ? getPropertyNameAtPosition(node, position) : undefined;
+
+        if (!node || !property) return { ...original, isIncomplete: true };
+
+        const trieSearch = getSortText(property).replace('$', '');
+        const isUnquoted = ts.isObjectLiteralExpression(node);
+        const entries = original.entries.flatMap((entry) => {
+          const transformedEntry = transformTokenPropertyEntry(entry);
+          return transformedEntry ? [transformedEntry] : [];
+        });
+
+        const baseTrie = createCompletionEntriesTrie(entries);
+        const selectorTrie = isUnquoted ? selectorCompletions.quoted : selectorCompletions.unquoted;
+        const baseResults = baseTrie.search(trieSearch);
+        const selectorResults = selectorTrie.search(trieSearch);
+        const results = [...baseResults, ...selectorResults];
+
+        original.entries = results.length ? results : original.entries;
       }
 
-      return original;
+      return { ...original, isIncomplete: true };
     };
 
     /* ---------------------------------------------------------------------------------------------

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -241,6 +241,9 @@ importers:
       culori:
         specifier: ^4.0.1
         version: 4.0.1
+      trie-search:
+        specifier: ^2.0.0
+        version: 2.0.0
     devDependencies:
       '@tokenami/dev':
         specifier: workspace:*
@@ -7513,6 +7516,11 @@ packages:
     resolution: {integrity: sha512-8Rf9Y83NBReMnx0gFzA8JImQACstCYWUplepDa9xprwwtmgEZUF0h/i5xSA625zB/I37EtrswSST6OXxwaaIJQ==}
     dev: true
 
+  /hasharray@1.1.2:
+    resolution: {integrity: sha512-7w3idwaVXX9gL9LiTCBSNKRGTBcp2WI/kf13UYeZ9+trOGBHVYHei6qtMY6DVnwGOouVUSRg0+L2xf4Q2/CmzA==}
+    dependencies:
+      jclass: 1.2.1
+
   /hasown@2.0.2:
     resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
     engines: {node: '>= 0.4'}
@@ -8245,6 +8253,10 @@ packages:
   /javascript-stringify@2.1.0:
     resolution: {integrity: sha512-JVAfqNPTvNq3sB/VHQJAFxN/sPgKnsKrCwyRt15zwNCdrMMJDdcEOdubuy+DuJYYdm0ox1J4uzEuYKkN+9yhVg==}
     dev: true
+
+  /jclass@1.2.1:
+    resolution: {integrity: sha512-mRx8uv1qJLOtxbRf3IWOQIH2ro7VIPn6ZkhbTcUJvJEslLzYA7BSATXDi/GR1yKYV9DASsjTZL+0YJPdqSMznw==}
+    engines: {node: '>= 0.6'}
 
   /jest-diff@29.7.0:
     resolution: {integrity: sha512-LMIgiIrhigmPrs03JHpxUh2yISK3vLFPkAodPeo0+BuF7wA2FoQbkEg1u8gBYBThncu7e1oEDUfIXVuTqLRUjw==}
@@ -12000,6 +12012,11 @@ packages:
     hasBin: true
     dev: true
 
+  /trie-search@2.0.0:
+    resolution: {integrity: sha512-AJMlAQ/6E5+K45SAOqzeqr0qXWqSREclp3mAWss0PvB9ifBL+QXn2LeZBgUBUifjj5ZtTpo4uKplqUnt9VZcdQ==}
+    dependencies:
+      hasharray: 1.1.2
+
   /trim-newlines@3.0.1:
     resolution: {integrity: sha512-c1PTsA3tYrIsLGkJkzHF+w9F2EyxfXGo4UyJc4pFL++FMjnq0HJS69T3M7d//gKrFKwy429bouPescbjecU+Zw==}
     engines: {node: '>=8'}
@@ -13113,4 +13130,5 @@ packages:
       '@tokenami/config': link:packages/config
       '@tokenami/dev': link:packages/dev
       culori: 4.0.1
+      trie-search: 2.0.0
     dev: true


### PR DESCRIPTION
# Summary

i'm working on a default theme for tokenami in a separate branch. it is quite large in terms of the OOTB aliases and selectors it provides which was harming intellisense performance. to solve, i've enabled `isIncomplete` on `getCompletionsAtPosition` in the typescript plugin so that it is called as the consumer types. this allows tokenami to return a subset of results based on what the user has typed.

with this change, selector properties will initially be listed with an underscore suffix and typing the underscore will update the results with the selector's associated properties. this behaves much like tailwind where typing `md` lists `md:` and then typing the colon updates the results accordingly.

while testing this, i realised that TypeScript intellisense doesn't handle properties that start with a number very well (see video) so i recommend naming responsive properties `xxl` instead of `2xl` for example for now, or you can press `CTRL+SPACE` as shown in the video to manually trigger intellisense. 

https://github.com/user-attachments/assets/54269a3d-7739-478f-ba67-a1d8ff74f866


## Release Notes

intellisense behaviour has changed significantly which may seem a little jarring at first. results are chunked so they will update with more specific matches when you type an underscore, similar to typing colon in tailwind. this was necessary to improve intellisense performance for projects with larger themes. 

if you select a result suffixed with underscore, press `CTRL+SPACE` to reopen intellisense with matches at that position.

https://github.com/user-attachments/assets/9c64f791-8480-4a22-9b26-4979851682aa

## Change Type

<!-- Please indicate the type of change this is -->

- [ ] `documentation`
- [ ] `patch`
- [x] `minor`
- [ ] `major`

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.0.60--canary.326.10442968167.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @tokenami/config@0.0.60--canary.326.10442968167.0
  npm install @tokenami/css@0.0.60--canary.326.10442968167.0
  npm install @tokenami/dev@0.0.60--canary.326.10442968167.0
  npm install @tokenami/ts-plugin@0.0.60--canary.326.10442968167.0
  # or 
  yarn add @tokenami/config@0.0.60--canary.326.10442968167.0
  yarn add @tokenami/css@0.0.60--canary.326.10442968167.0
  yarn add @tokenami/dev@0.0.60--canary.326.10442968167.0
  yarn add @tokenami/ts-plugin@0.0.60--canary.326.10442968167.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->


