### PR TITLE
add support for mixed custom properties and hardcoded values in theme modes

### DIFF
--- a/README.md
+++ b/README.md
@@ -656,57 +656,6 @@ Now you can set different gradient stops when applying the gradient, and intelli
 />
 ```
 
-#### CSS limitations
-
-Theme values containing custom properties are not applied to theme selectors in the generated stylesheet. Tokenami [must apply them to each element](https://codepen.io/jjenzz/pen/eYayMWo) to ensure custom properties are inherited from the element's style attribute. This means theme modes cannot mix custom properties with differing hardcoded values/variables. For example:
-
-```tsx
-// ❌
-{
-  light: {
-    surface: {
-      gradient: 'linear-gradient(to right, red, var(--surface-to))';
-    }
-  }
-  dark: {
-    surface: {
-      gradient: 'linear-gradient(to right, blue, var(--surface-to))';
-    }
-  }
-}
-```
-
-Instead, use matching custom properties and then use custom selectors to apply the different stops based on the theme mode:
-
-```tsx
-// ✅
-{
-  light: {
-    surface: {
-      gradient: 'linear-gradient(to right, var(--surface-from), var(--surface-to))';
-    }
-  }
-  dark: {
-    surface: {
-      gradient: 'linear-gradient(to right, var(--surface-from), var(--surface-to))';
-    }
-  }
-}
-```
-
-```tsx
-<div
-  style={css({
-    '--light_surface-from': 'var(--color_white)',
-    '--dark_surface-from': 'var(--color_black)',
-    '--surface-to': 'var(--color_primary)',
-    '--background': 'var(--surface_gradient)',
-  })}
-/>
-```
-
-This will ensure `--surface-from` is set to `var(--color_white)` in the light theme and `var(--color_black)` in the dark theme.
-
 ### Browserslist
 
 You can use [browserslist](https://browsersl.ist/) to add autoprefixing to your CSS properties in the generated CSS file. However, Tokenami currently doesn't support vendor-prefixed **values**, which is being tracked in [this issue](https://github.com/tokenami/tokenami/issues/103).

--- a/examples/design-system/src/tokenami.css
+++ b/examples/design-system/src/tokenami.css
@@ -1,12 +1,14 @@
-*, :before, :after {
-  box-sizing: border-box;
-}
+@layer global {
+  *, :before, :after {
+    box-sizing: border-box;
+  }
 
-body {
-  margin: 0;
-  padding: 0;
-  font-family: system-ui, sans-serif;
-  line-height: 1.5;
+  body {
+    margin: 0;
+    padding: 0;
+    font-family: system-ui, sans-serif;
+    line-height: 1.5;
+  }
 }
 
 @layer tokenami {
@@ -26,15 +28,27 @@ body {
     --alpha_30: .3;
     --alpha_80: .8;
     --anim_wiggle: wiggle 1s ease-in-out infinite;
-    --border_thin: 1px solid var(--color_slate-700);
     --font_sans: sans-serif;
     --radii_rounded: 10px;
   }
 
-  [style] {
+  :root, :root [style] {
+    --border_thin: 1px solid var(--color_slate-700);
+  }
+
+  .theme-light, .theme-light [style] {
+    --color_primary: rgba(241 245 249 / var(--_color-opacity, 1));
+    --color_secondary: rgba(51 65 85 / var(--_color-opacity, 1));
+    --color_slate-700: rgba(51 65 85 / var(--_color-opacity, 1));
+  }
+
+  .theme-dark, .theme-dark [style] {
     --color_primary: rgba(14 165 233 / var(--_color-opacity, 1));
     --color_secondary: rgba(241 245 249 / var(--_color-opacity, 1));
     --color_slate-700: rgba(51 65 85 / var(--_color-opacity, 1));
+  }
+
+  [style] {
     --background-color: initial;
     --hover: initial;
     --hover_background-color: initial;

--- a/examples/remix/public/tokenami.css
+++ b/examples/remix/public/tokenami.css
@@ -1,12 +1,14 @@
-*, :before, :after {
-  box-sizing: border-box;
-}
+@layer global {
+  *, :before, :after {
+    box-sizing: border-box;
+  }
 
-body {
-  margin: 0;
-  padding: 0;
-  font-family: system-ui, sans-serif;
-  line-height: 1.5;
+  body {
+    margin: 0;
+    padding: 0;
+    font-family: system-ui, sans-serif;
+    line-height: 1.5;
+  }
 }
 
 @layer tokenami {
@@ -26,7 +28,6 @@ body {
     --alpha_30: .3;
     --alpha_80: .8;
     --anim_wiggle: wiggle 1s ease-in-out infinite;
-    --border_thin: 1px solid var(--color_slate-700);
     --font_sans: sans-serif;
     --radii_circle: 9999px;
     --radii_none: none;
@@ -36,13 +37,17 @@ body {
     --size_screen-h: 100vh;
   }
 
+  :root, :root [style] {
+    --border_thin: 1px solid var(--color_slate-700);
+  }
+
   .theme-light {
     --pet_favourite: "🐶";
   }
 
-  [style] {
-    --color_primary: rgba(14 165 233 / var(--_color-opacity, 1));
-    --color_secondary: rgba(241 245 249 / var(--_color-opacity, 1));
+  .theme-light, .theme-light [style] {
+    --color_primary: rgba(241 245 249 / var(--_color-opacity, 1));
+    --color_secondary: rgba(51 65 85 / var(--_color-opacity, 1));
     --color_sky-500: rgba(14 165 233 / var(--_color-opacity, 1));
     --color_slate-100: rgba(241 245 249 / var(--_color-opacity, 1));
     --color_slate-700: rgba(51 65 85 / var(--_color-opacity, 1));
@@ -50,6 +55,14 @@ body {
 
   .theme-dark {
     --pet_favourite: "🐱";
+  }
+
+  .theme-dark, .theme-dark [style] {
+    --color_primary: rgba(14 165 233 / var(--_color-opacity, 1));
+    --color_secondary: rgba(241 245 249 / var(--_color-opacity, 1));
+    --color_sky-500: rgba(14 165 233 / var(--_color-opacity, 1));
+    --color_slate-100: rgba(241 245 249 / var(--_color-opacity, 1));
+    --color_slate-700: rgba(51 65 85 / var(--_color-opacity, 1));
   }
 
   [style] {

--- a/packages/dev/src/sheet.ts
+++ b/packages/dev/src/sheet.ts
@@ -248,20 +248,15 @@ function generateThemeTokens(tokenValues: Tokenami.TokenValue[], config: Tokenam
   });
 
   const rootStyles = Object.fromEntries(rootEntries);
-  // mode values applied to default selector must have the same shape
-  // so its okay for Object.fromEntries to be used here
   const modeStyles = Object.fromEntries(modeThemeEntries);
 
   return stringify({
+    ...rootStyles,
     [rootSelector]: {
       [Tokenami.gridProperty()]: config.grid,
       ...rootStyles[rootSelector],
     },
     ...modeStyles,
-    [DEFAULT_SELECTOR]: {
-      ...rootStyles[DEFAULT_SELECTOR],
-      ...modeStyles[DEFAULT_SELECTOR],
-    },
   });
 }
 
@@ -282,7 +277,7 @@ const getThemeEntries = (
   }
   return [
     [selector, themeValues],
-    [DEFAULT_SELECTOR, customPropertyThemeValues],
+    [`${selector}, ${selector} ${DEFAULT_SELECTOR}`, customPropertyThemeValues],
   ] as const;
 };
 


### PR DESCRIPTION
# Summary

originally, if a custom property was applied to a theme mode e.g. see `--surface-to` below:

```tsx
{
  light: {
    surface: {
      gradient: 'linear-gradient(to right, red, var(--surface-to))';
    }
  }
  dark: {
    surface: {
      gradient: 'linear-gradient(to right, blue, var(--surface-to))';
    }
  }
}
```

this would not apply the correct `red` or `blue` color stop based on theme because the `--surface_gradient` CSS variable would have been added to a `[style]` selector in the generated stylesheet. this change applies them to the correct selectors, e.g. `.dark, .dark [style]` so that the above can work as expected.

## Change Type

<!-- Please indicate the type of change this is -->

- [ ] `documentation`
- [ ] `patch`
- [x] `minor`
- [ ] `major`
