### PR TITLE
add grid toggle to stylesheet to preserve number property values

### DIFF
--- a/examples/design-system/src/tokenami.css
+++ b/examples/design-system/src/tokenami.css
@@ -83,8 +83,10 @@
       color: var(--color, revert-layer);
       border: var(--border, revert-layer);
       border-radius: var(--border-radius, revert-layer);
-      width: var(--width, revert-layer);
-      height: var(--height, revert-layer);
+      width: var(--_15jvuf0, var(--width, revert-layer));
+      --_15jvuf0: var(--width__calc) calc(var(--width) * var(--_grid));
+      height: var(--_r8sevj, var(--height, revert-layer));
+      --_r8sevj: var(--height__calc) calc(var(--height) * var(--_grid));
       transition: var(--transition, revert-layer);
       --_color-opacity: var(--color-opacity, revert-layer);
     }

--- a/examples/remix/public/tokenami.css
+++ b/examples/remix/public/tokenami.css
@@ -158,15 +158,20 @@
       color: var(--color, revert-layer);
       border: var(--border, revert-layer);
       border-radius: var(--border-radius, revert-layer);
-      width: var(--width, revert-layer);
-      height: var(--height, revert-layer);
+      width: var(--_15jvuf0, var(--width, revert-layer));
+      --_15jvuf0: var(--width__calc) calc(var(--width) * var(--_grid));
+      height: var(--_r8sevj, var(--height, revert-layer));
+      --_r8sevj: var(--height__calc) calc(var(--height) * var(--_grid));
       transition: var(--transition, revert-layer);
-      min-height: var(--min-height, revert-layer);
+      min-height: var(--_1ljreoo, var(--min-height, revert-layer));
+      --_1ljreoo: var(--min-height__calc) calc(var(--min-height) * var(--_grid));
       display: var(--display, revert-layer);
       text-align: var(--text-align, revert-layer);
       overflow: var(--overflow, revert-layer);
-      margin: var(--margin, revert-layer);
-      padding: var(--padding, revert-layer);
+      margin: var(--_n3khrc, var(--margin, revert-layer));
+      --_n3khrc: var(--margin__calc) calc(var(--margin) * var(--_grid));
+      padding: var(--_2dqpfb, var(--padding, revert-layer));
+      --_2dqpfb: var(--padding__calc) calc(var(--padding) * var(--_grid));
       object-fit: var(--object-fit, revert-layer);
     }
   }
@@ -182,23 +187,32 @@
       flex-direction: var(--flex-direction, revert-layer);
       align-items: var(--align-items, revert-layer);
       justify-content: var(--justify-content, revert-layer);
-      padding-left: var(--padding-left, revert-layer);
-      padding-right: var(--padding-right, revert-layer);
-      padding-top: var(--padding-top, revert-layer);
-      padding-bottom: var(--padding-bottom, revert-layer);
+      padding-left: var(--_1l6ill9, var(--padding-left, revert-layer));
+      --_1l6ill9: var(--padding-left__calc) calc(var(--padding-left) * var(--_grid));
+      padding-right: var(--_eeg826, var(--padding-right, revert-layer));
+      --_eeg826: var(--padding-right__calc) calc(var(--padding-right) * var(--_grid));
+      padding-top: var(--_alekcd, var(--padding-top, revert-layer));
+      --_alekcd: var(--padding-top__calc) calc(var(--padding-top) * var(--_grid));
+      padding-bottom: var(--_1if2c2d, var(--padding-bottom, revert-layer));
+      --_1if2c2d: var(--padding-bottom__calc) calc(var(--padding-bottom) * var(--_grid));
       line-height: var(--line-height, revert-layer);
       font-weight: var(--font-weight, revert-layer);
-      margin-bottom: var(--margin-bottom, revert-layer);
-      margin-left: var(--margin-left, revert-layer);
-      margin-right: var(--margin-right, revert-layer);
+      margin-bottom: var(--_1rgufc4, var(--margin-bottom, revert-layer));
+      --_1rgufc4: var(--margin-bottom__calc) calc(var(--margin-bottom) * var(--_grid));
+      margin-left: var(--_1u4ehd0, var(--margin-left, revert-layer));
+      --_1u4ehd0: var(--margin-left__calc) calc(var(--margin-left) * var(--_grid));
+      margin-right: var(--_6ffjt3, var(--margin-right, revert-layer));
+      --_6ffjt3: var(--margin-right__calc) calc(var(--margin-right) * var(--_grid));
       border-color: var(--border-color, revert-layer);
     }
   }
 
   @layer tk3 {
     [style] {
-      background-position-x: var(--background-position-x, revert-layer);
-      background-position-y: var(--background-position-y, revert-layer);
+      background-position-x: var(--_1k3at6j, var(--background-position-x, revert-layer));
+      --_1k3at6j: var(--background-position-x__calc) calc(var(--background-position-x) * var(--_grid));
+      background-position-y: var(--_1k3at6i, var(--background-position-y, revert-layer));
+      --_1k3at6i: var(--background-position-y__calc) calc(var(--background-position-y) * var(--_grid));
     }
   }
 
@@ -231,15 +245,23 @@
       --_1hh3291: var(--xl) var(--xl_border-radius);
       --_1a98csj: var(--2xl) var(--2xl_border-radius);
       width: var(--_lgvp90, var(--_1qgla5e, var(--_3q4l9b, var(--_rmk1kf, revert-layer))));
-      --_rmk1kf: var(--md) var(--md_width);
-      --_3q4l9b: var(--lg) var(--lg_width);
-      --_1qgla5e: var(--xl) var(--xl_width);
-      --_lgvp90: var(--2xl) var(--2xl_width);
+      --_rmk1kf: var(--md) var(--_4ps7bs, var(--md_width));
+      --_4ps7bs: var(--md_width__calc) calc(var(--md_width) * var(--_grid));
+      --_3q4l9b: var(--lg) var(--_mj6pr8, var(--lg_width));
+      --_mj6pr8: var(--lg_width__calc) calc(var(--lg_width) * var(--_grid));
+      --_1qgla5e: var(--xl) var(--_a41ah1, var(--xl_width));
+      --_a41ah1: var(--xl_width__calc) calc(var(--xl_width) * var(--_grid));
+      --_lgvp90: var(--2xl) var(--_17j0oi7, var(--2xl_width));
+      --_17j0oi7: var(--2xl_width__calc) calc(var(--2xl_width) * var(--_grid));
       height: var(--_18bne5j, var(--_131ipn5, var(--_midacu, var(--_1hvgbk2, revert-layer))));
-      --_1hvgbk2: var(--md) var(--md_height);
-      --_midacu: var(--lg) var(--lg_height);
-      --_131ipn5: var(--xl) var(--xl_height);
-      --_18bne5j: var(--2xl) var(--2xl_height);
+      --_1hvgbk2: var(--md) var(--_11v92un, var(--md_height));
+      --_11v92un: var(--md_height__calc) calc(var(--md_height) * var(--_grid));
+      --_midacu: var(--lg) var(--_1fml2u5, var(--lg_height));
+      --_1fml2u5: var(--lg_height__calc) calc(var(--lg_height) * var(--_grid));
+      --_131ipn5: var(--xl) var(--_1d0b81c, var(--xl_height));
+      --_1d0b81c: var(--xl_height__calc) calc(var(--xl_height) * var(--_grid));
+      --_18bne5j: var(--2xl) var(--_1ugpr66, var(--2xl_height));
+      --_1ugpr66: var(--2xl_height__calc) calc(var(--2xl_height) * var(--_grid));
       animation: var(--_1upk2ho, revert-layer);
       --_1upk2ho: var(--hover) var(--hover_animation);
       display: var(--_cbroqb, revert-layer);
@@ -247,7 +269,8 @@
       text-align: var(--_1hooa64, revert-layer);
       --_1hooa64: var(--md) var(--md_text-align);
       padding: var(--_1tfdub6, revert-layer);
-      --_1tfdub6: var(--md) var(--md_padding);
+      --_1tfdub6: var(--md) var(--_1injeaf, var(--md_padding));
+      --_1injeaf: var(--md_padding__calc) calc(var(--md_padding) * var(--_grid));
       content: var(--_bpstpr, var(--_bkpo73, revert-layer));
       --_bkpo73: var(--after) var(--after_content);
       --_bpstpr: var(--md_after) var(--md_after_content);
@@ -268,9 +291,11 @@
       --_1tqbkib: var(--xl) var(--xl_font-size);
       --_1qfo97: var(--2xl) var(--2xl_font-size);
       padding-left: var(--_13ih5qc, revert-layer);
-      --_13ih5qc: var(--child-para) var(--child-para_padding-left);
+      --_13ih5qc: var(--child-para) var(--_tapqil, var(--child-para_padding-left));
+      --_tapqil: var(--child-para_padding-left__calc) calc(var(--child-para_padding-left) * var(--_grid));
       padding-right: var(--_1h6o3of, revert-layer);
-      --_1h6o3of: var(--child-para) var(--child-para_padding-right);
+      --_1h6o3of: var(--child-para) var(--_d9jvo8, var(--child-para_padding-right));
+      --_d9jvo8: var(--child-para_padding-right__calc) calc(var(--child-para_padding-right) * var(--_grid));
     }
   }
 

--- a/packages/css/src/css.ts
+++ b/packages/css/src/css.ts
@@ -86,19 +86,22 @@ function createCss(config: Tokenami.Config, options?: CreateCssOptions) {
 
     if (cached) return cached;
 
-    [baseStyles, ...overrides].forEach((originalStyles) => {
-      if (!originalStyles) return;
+    const allStyles = [baseStyles, ...overrides];
+
+    for (const originalStyles of allStyles) {
+      if (!originalStyles) continue;
 
       for (const [key, value] of Object.entries(originalStyles)) {
         const tokenProperty = Tokenami.TokenProperty.safeParse(key);
         if (!tokenProperty.success) {
-          Object.assign(overriddenStyles, { [key]: value });
+          overriddenStyles[key as any] = value;
           continue;
         }
 
         const parts = Tokenami.getTokenPropertySplit(tokenProperty.output);
         const cssProperties = Tokenami.getCSSPropertiesForAlias(parts.alias, config.aliases);
 
+        // most the time this will only be one property
         for (const cssProperty of cssProperties) {
           const long = createLonghandProperty(tokenProperty.output, cssProperty);
           const isNumber = typeof value === 'number' && value > 0;
@@ -109,16 +112,15 @@ function createCss(config: Tokenami.Config, options?: CreateCssOptions) {
           overrideLonghands(overriddenStyles, tokenPropertyLong);
           // this must happen each iteration so that each override applies to the
           // mutated css object from the previous override iteration
-          Object.assign(overriddenStyles, {
-            // add grid toggle to enable grid calc for grid properties. set it to
-            // undefined to remove the toggle if it was added by a previous iteration.
-            // it cannot be an empty string because some fws strip it (e.g. vite)
-            [tokenPropertyLong + '__calc']: isNumber ? '/*on*/' : undefined,
-            [tokenPropertyLong]: value,
-          });
+          overriddenStyles[tokenPropertyLong as any] = value;
+          // add grid toggle to enable grid calc for grid properties. set it to
+          // undefined to remove the toggle if it was added by a previous iteration.
+          // it cannot be an empty string because some fws strip it (e.g. vite)
+          // @ts-ignore
+          overriddenStyles[calcProperty(tokenPropertyLong)] = isNumber ? '/*on*/' : undefined;
         }
       }
-    });
+    }
 
     cache.set(cacheId, overriddenStyles);
     return overriddenStyles;
@@ -170,10 +172,19 @@ function overrideLonghands(style: Record<string, any>, tokenProperty: Tokenami.T
   const longhands: string[] = Tokenami.mapShorthandToLonghands.get(parts.alias as any) || [];
   longhands.forEach((longhand) => {
     const tokenPropertyLong = createLonghandProperty(tokenProperty, longhand);
-    if (style[tokenPropertyLong]) delete style[tokenPropertyLong];
+    if (style[tokenPropertyLong]) {
+      delete style[tokenPropertyLong];
+      delete style[calcProperty(tokenPropertyLong)];
+    }
     overrideLonghands(style, tokenPropertyLong);
   });
 }
+
+/* -------------------------------------------------------------------------------------------------
+ * calcProperty
+ * -----------------------------------------------------------------------------------------------*/
+
+const calcProperty = (property: string) => property + '__calc';
 
 /* -------------------------------------------------------------------------------------------------
  * createLonghandProperty

--- a/packages/css/src/test/compose.test.ts
+++ b/packages/css/src/test/compose.test.ts
@@ -15,7 +15,7 @@ const baseStyles = Object.freeze({
 
 const baseStylesOutput = Object.freeze({
   ...baseStyles,
-  '--md_padding': 'calc(var(--_grid) * 2)',
+  '--md_padding__calc': '/*on*/',
 }) as {};
 
 const disabledStyles = Object.freeze({
@@ -147,7 +147,8 @@ describe('css compose', () => {
     it<TestContext>('should add shorthand styles', (context) => {
       const expected = {
         '--font': 'arial',
-        '--padding': 'calc(var(--_grid) * 30)',
+        '--padding': 30,
+        '--padding__calc': '/*on*/',
         '--border': '1px dashed',
       };
       expect(hasStyles(context.output, expected)).toBe(true);

--- a/packages/css/src/test/create.test.ts
+++ b/packages/css/src/test/create.test.ts
@@ -53,20 +53,20 @@ describe('css returned from createCss', () => {
     });
 
     it<TestContext>('should remove first override padding styles', (context) => {
-      const unexpected = { '--padding-left': 'calc(var(--_grid) * 10)' };
+      const unexpected = { '--padding-left': 10 };
       expect(hasSomeStyles(context.output, unexpected)).toBe(false);
     });
 
     it<TestContext>('should remove second override padding styles', (context) => {
       const unexpected = {
-        '--padding-left': 'calc(var(--_grid) * 20)',
-        '--padding-right': 'calc(var(--_grid) * 20)',
+        '--padding-left': 20,
+        '--padding-right': 20,
       };
       expect(hasSomeStyles(context.output, unexpected)).toBe(false);
     });
 
     it<TestContext>('should keep final override style', (context) => {
-      const expected = { '--padding': 'calc(var(--_grid) * 40)' };
+      const expected = { '--padding': 40, '--padding__calc': '/*on*/' };
       expect(hasStyles(context.output, expected)).toBe(true);
     });
 
@@ -124,8 +124,10 @@ describe('css returned from createCss', () => {
 
     it<TestContext>('should override correctly', (context) => {
       expect(context.output).toStrictEqual({
-        '--padding-left': 'calc(var(--_grid) * 20)',
-        '--padding-right': 'calc(var(--_grid) * 20)',
+        '--padding-left': 20,
+        '--padding-right': 20,
+        '--padding-left__calc': '/*on*/',
+        '--padding-right__calc': '/*on*/',
       });
     });
   });

--- a/packages/css/src/test/css.test.ts
+++ b/packages/css/src/test/css.test.ts
@@ -16,7 +16,7 @@ describe('css utility', () => {
     });
 
     it<TestContext>('should convert value to calc', (context) => {
-      expect(context.output).toEqual({ '--padding-left': 'calc(var(--_grid) * 10)' });
+      expect(context.output).toEqual({ '--padding-left': 10, '--padding-left__calc': '/*on*/' });
     });
   });
 
@@ -26,7 +26,17 @@ describe('css utility', () => {
     });
 
     it<TestContext>('should keep the shorthand styles only', (context) => {
-      expect(context.output).toEqual({ '--padding': 'calc(var(--_grid) * 20)' });
+      expect(context.output).toEqual({ '--padding': 20, '--padding__calc': '/*on*/' });
+    });
+  });
+
+  describe('when called with a non-numeric override', () => {
+    beforeEach<TestContext>((context) => {
+      context.output = css({ '--padding': 20 }, { '--padding': 'var(---, 30px)' });
+    });
+
+    it<TestContext>('should remove calc toggle', (context) => {
+      expect(context.output).toEqual({ '--padding': 'var(---, 30px)' });
     });
   });
 });

--- a/packages/dev/src/declarations.ts
+++ b/packages/dev/src/declarations.ts
@@ -62,7 +62,7 @@ type PropertyThemeValue<ThemeKey extends string> =
   | Tokenami.ArbitraryValue
   | CSS.Globals
   | TokensByThemeKey[ThemeKey]
-  | (ThemeKey extends 'grid' ? Tokenami.GridValue : never);
+  | (ThemeKey extends 'grid' | 'number' ? Tokenami.GridValue : never);
 
 type TokensByThemeKey = { [key: string]: never } & {
   [K in keyof Theme]: keyof Theme[K] extends `${infer Token}`


### PR DESCRIPTION
# Summary

the `css` utility had a hardcoded assumption that if a `number` is passed to a property then it is a grid value, and so it would wrap it in `calc`. this assumption was made to avoid requiring a dependency on the user's config to use grid values, lowering the barrier to entry when getting started with tokenami.

this worked fine—till now. i've been working on a separate branch to introduce a ready-made theme package and as part of that, i wanted to include fluid spacing/font size support. it requires passing unitless values to calculate the fluid values so i've had to rethink the `number === grid value` assumption.

instead of wrapping numbers in calc inline, this pr adds a `--${property}__calc: ;` toggle alongside number properties which toggles the grid calculation in the stylesheet for _grid_ values. for instance:

```tsx
style={css({ '--padding': 2 })}
```

becomes:

```tsx
style="--padding:2;--padding__calc:;"
```

this triggers a toggle in the stylesheet that looks something like:

```css
padding: var(--_1l6ill9, var(--padding, revert-layer));
--_1l6ill9: var(--padding__calc) calc(var(--padding) * var(--_grid));
```

if the toggle doesn't exist, it will fallback to the `--padding` value directly.

i'm not too worried about the devtools developer experience here. trying to maintain a good default browser devtools experience has been holding me back a bit so i am thinking about improving that with a custom browser extension later instead. 

## Change Type

<!-- Please indicate the type of change this is -->

- [ ] `documentation`
- [ ] `patch`
- [x] `minor`
- [ ] `major`

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.0.62--canary.330.10599212164.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @tokenami/config@0.0.62--canary.330.10599212164.0
  npm install @tokenami/css@0.0.62--canary.330.10599212164.0
  npm install @tokenami/dev@0.0.62--canary.330.10599212164.0
  npm install @tokenami/ts-plugin@0.0.62--canary.330.10599212164.0
  # or 
  yarn add @tokenami/config@0.0.62--canary.330.10599212164.0
  yarn add @tokenami/css@0.0.62--canary.330.10599212164.0
  yarn add @tokenami/dev@0.0.62--canary.330.10599212164.0
  yarn add @tokenami/ts-plugin@0.0.62--canary.330.10599212164.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
