### PR TITLE
make CSS vars inherited by default when equivalent CSS property is inheritable

### DIFF
--- a/examples/design-system/src/button/button.tsx
+++ b/examples/design-system/src/button/button.tsx
@@ -35,11 +35,10 @@ const button = css.compose({
     size: {
       small: {
         '--font': 'var(--text_base)',
-        '--font-family': 'var(--font_sans)',
       },
       large: {
         '--font': 'var(--text_xl)',
-        '--font-family': 'var(--font_sans)',
+        '--font-family': 'var(--font_mono)',
       },
     },
   },

--- a/examples/design-system/src/tokenami.css
+++ b/examples/design-system/src/tokenami.css
@@ -1,4 +1,12 @@
 @layer global {
+  :root {
+    --font-family: ui-sans-serif, system-ui, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
+    --font-stretch: normal;
+    --font-style: normal;
+    --font-variant: normal;
+    --font-weight: normal;
+  }
+
   *, :before, :after {
     box-sizing: border-box;
     border: 0 solid;
@@ -9,11 +17,11 @@
   html, :host {
     -webkit-text-size-adjust: 100%;
     tab-size: 4;
+    line-height: 1.5;
+    font-family: var(--font-family);
     font-feature-settings: normal;
     font-variation-settings: normal;
     -webkit-tap-highlight-color: transparent;
-    font-family: ui-sans-serif, system-ui, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol, Noto Color Emoji;
-    line-height: 1.5;
   }
 
   body {
@@ -47,9 +55,10 @@
   }
 
   code, kbd, samp, pre {
+    --font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+    font-family: var(--font-family);
     font-feature-settings: normal;
     font-variation-settings: normal;
-    font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, Liberation Mono, Courier New, monospace;
     font-size: 1em;
   }
 
@@ -175,15 +184,15 @@
   :root {
     --_grid: .25rem;
     --anim_wiggle: wiggle 1s ease-in-out infinite;
-    --font_sans: ui-sans-serif, system-ui, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
+    --font_mono: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
     --line_px: .0625rem solid;
     --morph_all: all cubic-bezier(.4, 0, .2, 1) .15s;
     --radii_lg: .5rem;
   }
 
   :root, :root [style] {
-    --text_base: 1rem / 1.5rem var(--font-family);
-    --text_xl: 1.25rem / 1.75rem var(--font-family);
+    --text_base: var(--font-stretch) var(--font-style) var(--font-variant) var(--font-weight) 1rem / 1.5rem var(--font-family);
+    --text_xl: var(--font-stretch) var(--font-style) var(--font-variant) var(--font-weight) 1.25rem / 1.75rem var(--font-family);
   }
 
   :root, [data-theme="light"] {
@@ -206,7 +215,6 @@
     --hover_background-color: initial;
     --\{\&\;focus\;hover\}: initial;
     --\{\&\;focus\;hover\}_background-color: initial;
-    --color: initial;
     --border-block-end-width: initial;
     --border-color: initial;
     --border-radius: initial;
@@ -214,23 +222,11 @@
     --block-size: initial;
     --transition: initial;
     --hover_animation: initial;
-    --font: initial;
     --sm: initial;
-    --sm_font: initial;
     --md: initial;
-    --md_font: initial;
     --lg: initial;
-    --lg_font: initial;
     --xl: initial;
-    --xl_font: initial;
     --xxl: initial;
-    --xxl_font: initial;
-    --font-family: initial;
-    --sm_font-family: initial;
-    --md_font-family: initial;
-    --lg_font-family: initial;
-    --xl_font-family: initial;
-    --xxl_font-family: initial;
   }
 
   @layer tk1 {

--- a/examples/remix/public/tokenami.css
+++ b/examples/remix/public/tokenami.css
@@ -1,4 +1,12 @@
 @layer global {
+  :root {
+    --font-family: ui-sans-serif, system-ui, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
+    --font-stretch: normal;
+    --font-style: normal;
+    --font-variant: normal;
+    --font-weight: normal;
+  }
+
   *, :before, :after {
     box-sizing: border-box;
     border: 0 solid;
@@ -9,11 +17,11 @@
   html, :host {
     -webkit-text-size-adjust: 100%;
     tab-size: 4;
+    line-height: 1.5;
+    font-family: var(--font-family);
     font-feature-settings: normal;
     font-variation-settings: normal;
     -webkit-tap-highlight-color: transparent;
-    font-family: ui-sans-serif, system-ui, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol, Noto Color Emoji;
-    line-height: 1.5;
   }
 
   body {
@@ -45,9 +53,10 @@
   }
 
   code, kbd, samp, pre {
+    --font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+    font-family: var(--font-family);
     font-feature-settings: normal;
     font-variation-settings: normal;
-    font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, Liberation Mono, Courier New, monospace;
     font-size: 1em;
   }
 
@@ -182,6 +191,7 @@
     --_grid: .25rem;
     --anim_pulse: pulse 2s cubic-bezier(.4, 0, .6, 1) infinite;
     --anim_wiggle: wiggle 1s ease-in-out infinite;
+    --font_mono: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
     --font_sans: ui-sans-serif, system-ui, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
     --leading_7: 1.75rem;
     --leading_loose: 2;
@@ -202,8 +212,8 @@
   }
 
   :root, :root [style] {
-    --text_base: 1rem / 1.5rem var(--font-family);
-    --text_xl: 1.25rem / 1.75rem var(--font-family);
+    --text_base: var(--font-stretch) var(--font-style) var(--font-variant) var(--font-weight) 1rem / 1.5rem var(--font-family);
+    --text_xl: var(--font-stretch) var(--font-style) var(--font-variant) var(--font-weight) 1.25rem / 1.75rem var(--font-family);
   }
 
   :root, [data-theme="light"] {
@@ -233,17 +243,11 @@
   }
 
   [style] {
-    --font-family: initial;
     --sm: initial;
-    --sm_font-family: initial;
     --md: initial;
-    --md_font-family: initial;
     --lg: initial;
-    --lg_font-family: initial;
     --xl: initial;
-    --xl_font-family: initial;
     --xxl: initial;
-    --xxl_font-family: initial;
     --background-color: initial;
     --hover: initial;
     --hover_background-color: initial;
@@ -252,9 +256,6 @@
     --child-para: initial;
     --selection: initial;
     --selection_background-color: initial;
-    --color: initial;
-    --selection_color: initial;
-    --hover_color: initial;
     --border-block-end-width: initial;
     --border-color: initial;
     --border-radius: initial;
@@ -277,12 +278,6 @@
     --xxl_block-size: initial;
     --transition: initial;
     --hover_animation: initial;
-    --font: initial;
-    --sm_font: initial;
-    --md_font: initial;
-    --lg_font: initial;
-    --xl_font: initial;
-    --xxl_font: initial;
     --min-height: initial;
     --background-size: initial;
     --background-image: initial;
@@ -294,22 +289,16 @@
     --align-items: initial;
     --justify-content: initial;
     --padding-inline: initial;
-    --text-align: initial;
-    --md_text-align: initial;
     --overflow: initial;
     --margin: initial;
     --padding-block: initial;
     --md_padding: initial;
     --padding: initial;
-    --line-height: initial;
     --after: initial;
     --after_content: initial;
     --md_after: initial;
     --md_after_content: initial;
     --padding-block-start: initial;
-    --font-size: initial;
-    --xxl_font-size: initial;
-    --font-weight: initial;
     --margin-block-end: initial;
     --margin-inline: initial;
     --margin-inline-start: initial;
@@ -320,9 +309,9 @@
 
   @layer tk1 {
     [style] {
-      color: var(--color, revert-layer);
       border-radius: var(--border-radius, revert-layer);
       transition: var(--transition, revert-layer);
+      color: var(--color, revert-layer);
       font: var(--font, revert-layer);
       min-height: var(--_1ljreoo, var(--min-height, revert-layer));
       --_1ljreoo: var(--min-height__calc) calc(var(--min-height) * var(--_grid));
@@ -341,6 +330,10 @@
   @layer tk2 {
     [style] {
       font-family: var(--font-family, revert-layer);
+      font-stretch: var(--font-stretch, revert-layer);
+      font-style: var(--font-style, revert-layer);
+      font-variant: var(--font-variant, revert-layer);
+      font-weight: var(--font-weight, revert-layer);
       background-color: var(--background-color, revert-layer);
       border-color: var(--border-color, revert-layer);
       background-size: var(--background-size, revert-layer);
@@ -350,7 +343,6 @@
       justify-content: var(--justify-content, revert-layer);
       line-height: var(--line-height, revert-layer);
       font-size: var(--font-size, revert-layer);
-      font-weight: var(--font-weight, revert-layer);
     }
   }
 
@@ -403,9 +395,6 @@
 
   @layer tks1 {
     [style], [style] > p, [style*="selection_"]::selection, [style]:after {
-      color: var(--_853it7, var(--_1v8oal9, revert-layer));
-      --_1v8oal9: var(--selection) var(--selection_color);
-      --_853it7: var(--hover) var(--hover_color);
       border-radius: var(--_18mum7u, var(--_1ckstr7, var(--_1hh3291, var(--_1aut28, var(--_176qpn4, var(--_117pkm7, revert-layer))))));
       --_18mum7u: var(--child-para) var(--child-para_border-radius);
       --_117pkm7: var(--sm) var(--sm_border-radius);
@@ -415,6 +404,9 @@
       --_1ckstr7: var(--xxl) var(--xxl_border-radius);
       animation: var(--_1upk2ho, revert-layer);
       --_1upk2ho: var(--hover) var(--hover_animation);
+      color: var(--_853it7, var(--_1v8oal9, revert-layer));
+      --_1v8oal9: var(--selection) var(--selection_color);
+      --_853it7: var(--hover) var(--hover_color);
       font: var(--_1gipe25, var(--_mhgvlt, var(--_10ti6tm, var(--_104t2cq, var(--_qp58in, revert-layer)))));
       --_qp58in: var(--sm) var(--sm_font);
       --_104t2cq: var(--md) var(--md_font);

--- a/packages/dev/src/supports.ts
+++ b/packages/dev/src/supports.ts
@@ -487,9 +487,42 @@ const supported: AllProperties = {
   ...supportedLogical,
 };
 
+const inheritedProperties = new Set([
+  'azimuth',
+  'border-collapse',
+  'border-spacing',
+  'caption-side',
+  'color',
+  'cursor',
+  'direction',
+  'empty-cells',
+  'font-family',
+  'font-size',
+  'font-style',
+  'font-variant',
+  'font-weight',
+  'font-stretch',
+  'font',
+  'letter-spacing',
+  'line-height',
+  'list-style-image',
+  'list-style-position',
+  'list-style-type',
+  'list-style',
+  'orphans',
+  'quotes',
+  'text-align',
+  'text-indent',
+  'text-transform',
+  'visibility',
+  'white-space',
+  'widows',
+  'word-spacing',
+]);
+
 type LogicalProperties = keyof typeof supportedLogical;
 const supportedProperties = new Set(Object.keys(supported)) as Set<CSSProperty>;
 const supportedLogicalProperties = new Set(Object.keys(supportedLogical)) as Set<LogicalProperties>;
 
 export type { CSSProperty };
-export { supportedProperties, supportedLogicalProperties };
+export { supportedProperties, supportedLogicalProperties, inheritedProperties };

--- a/packages/ds/src/index.ts
+++ b/packages/ds/src/index.ts
@@ -11,6 +11,10 @@ const BP_2XL = 1536;
 
 const rem = <T extends number>(value: T) => `${value / BASE_FONT_SIZE}rem` as const;
 const remBreakpoint = <T extends number>(bp: T) => `@media (min-width: ${rem(bp)})` as const;
+
+const font = <S extends string, L extends string>(fontSize: S, lineHeight: L) =>
+  `var(--font-stretch) var(--font-style) var(--font-variant) var(--font-weight) ${fontSize}/${lineHeight} var(--font-family)` as const;
+
 const optionalViaGradient = <T extends string>(direction: T) =>
   `linear-gradient(${direction}, var(--gradient-from) var(--gradient-from-stop,/**/), var(---via, var(--gradient-to) var(--gradient-to-stop,/**/)));
   ---via: var(--gradient-via) var(--gradient-via-stop,/**/), var(--gradient-to)` as const;
@@ -85,6 +89,14 @@ export default createConfig({
   },
   // tweaked version of preflight from Tailwind https://github.com/tailwindlabs/tailwindcss/blob/next/packages/tailwindcss/preflight.css
   globalStyles: {
+    ':root': {
+      /* set up default vars for var(text_*) tokens */
+      ['--font-family' as string]: `ui-sans-serif, system-ui, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji"`,
+      ['--font-stretch' as string]: 'normal',
+      ['--font-style' as string]: 'normal',
+      ['--font-variant' as string]: 'normal',
+      ['--font-weight' as string]: 'normal',
+    },
     '*, *::before, *::after': {
       boxSizing: 'border-box',
       margin: 0,
@@ -95,7 +107,7 @@ export default createConfig({
       lineHeight: 1.5,
       WebkitTextSizeAdjust: '100%',
       tabSize: 4,
-      fontFamily: `ui-sans-serif, system-ui, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji"`,
+      fontFamily: 'var(--font-family)',
       fontFeatureSettings: 'normal',
       fontVariationSettings: 'normal',
       WebkitTapHighlightColor: 'transparent',
@@ -123,7 +135,8 @@ export default createConfig({
       fontWeight: 'bolder',
     },
     'code, kbd, samp, pre': {
-      fontFamily: `ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace`,
+      ['--font-family' as string]: `ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace`,
+      fontFamily: 'var(--font-family)',
       fontFeatureSettings: 'normal',
       fontVariationSettings: 'normal',
       fontSize: '1em',
@@ -1087,19 +1100,19 @@ export default createConfig({
       '1000': '1000ms',
     },
     text: {
-      xs: `${rem(12)}/1rem var(--font-family)`,
-      sm: `${rem(14)}/1.25rem var(--font-family)`,
-      base: `${rem(16)}/1.5rem var(--font-family)`,
-      lg: `${rem(18)}/1.75rem var(--font-family)`,
-      xl: `${rem(20)}/1.75rem var(--font-family)`,
-      '2xl': `${rem(24)}/2rem var(--font-family)`,
-      '3xl': `${rem(30)}/2.25rem var(--font-family)`,
-      '4xl': `${rem(36)}/2.5rem var(--font-family)`,
-      '5xl': `${rem(48)}/1 var(--font-family)`,
-      '6xl': `${rem(60)}/1 var(--font-family)`,
-      '7xl': `${rem(72)}/1 var(--font-family)`,
-      '8xl': `${rem(96)}/1 var(--font-family)`,
-      '9xl': `${rem(128)}/1 var(--font-family)`,
+      xs: font(rem(12), rem(16)),
+      sm: font(rem(14), rem(20)),
+      base: font(rem(16), rem(24)),
+      lg: font(rem(18), rem(28)),
+      xl: font(rem(20), rem(28)),
+      '2xl': font(rem(24), rem(32)),
+      '3xl': font(rem(30), rem(36)),
+      '4xl': font(rem(36), rem(40)),
+      '5xl': font(rem(48), '1'),
+      '6xl': font(rem(60), '1'),
+      '7xl': font(rem(72), '1'),
+      '8xl': font(rem(96), '1'),
+      '9xl': font(rem(128), '1'),
     },
     'text-size': {
       xs: rem(12),


### PR DESCRIPTION
# Summary

improves the `var(text_*)` token behaviour in the DS. 

the `font` css property requires a font-size and font-family to be specified for it to work. this change means we can setup the `text` tokens to have values like `1rem/1.2 var(--font-family)` and then using `font` will set font-size/line-height, and _inherit_ the font-family.

an edge case to be aware of here is when consumer is explicitly passing `--font` as an override on a specific element:

```tsx
// note `--font` passed as second param (an override)
css({ '--font-family': 'var(font_sans)' }, { '--font': 'var(--text_sm)' })
```

in this case, the `--font` rule will remove the local `--font-family` style because it is a shorthand for that property. shorthands override longhands when they're applied after them in a CSS stylesheet. this will reset the font family to its _inherited_ family.

## Change Type

<!-- Please indicate the type of change this is -->

- [ ] `documentation`
- [ ] `patch`
- [x] `minor`
- [ ] `major`

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.0.63--canary.335.10632670354.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @tokenami/config@0.0.63--canary.335.10632670354.0
  npm install @tokenami/css@0.0.63--canary.335.10632670354.0
  npm install @tokenami/dev@0.0.63--canary.335.10632670354.0
  npm install @tokenami/ds@0.0.63--canary.335.10632670354.0
  npm install @tokenami/ts-plugin@0.0.63--canary.335.10632670354.0
  # or 
  yarn add @tokenami/config@0.0.63--canary.335.10632670354.0
  yarn add @tokenami/css@0.0.63--canary.335.10632670354.0
  yarn add @tokenami/dev@0.0.63--canary.335.10632670354.0
  yarn add @tokenami/ds@0.0.63--canary.335.10632670354.0
  yarn add @tokenami/ts-plugin@0.0.63--canary.335.10632670354.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
