### PR TITLE
prevent colour swatches in intellisense for number strings (e.g. font-weights)

### DIFF
--- a/packages/ts-plugin/src/index.ts
+++ b/packages/ts-plugin/src/index.ts
@@ -791,7 +791,10 @@ function replaceCssVarsWithFallback(value: string) {
 function isColorThemeEntry(modeValues: Record<string, string>) {
   try {
     const firstValue = Object.values(modeValues || {})?.[0];
-    return Boolean(culori.parse(replaceCssVarsWithFallback(firstValue || '')));
+    // culori parses number strings as colours e.g. "300" becomes `{ mode: 'rgb', r: 0,2, g: 0, b: 0 }`
+    // so we make sure value cannot coerce to a number before parsing
+    const isString = isNaN(Number(firstValue));
+    return isString ? Boolean(culori.parse(replaceCssVarsWithFallback(firstValue || ''))) : false;
   } catch {
     return false;
   }


### PR DESCRIPTION
# Summary

Closes #329 

## Change Type

<!-- Please indicate the type of change this is -->

- [ ] `documentation`
- [x] `patch`
- [ ] `minor`
- [ ] `major`

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.0.63--canary.336.10636664738.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @tokenami/config@0.0.63--canary.336.10636664738.0
  npm install @tokenami/css@0.0.63--canary.336.10636664738.0
  npm install @tokenami/dev@0.0.63--canary.336.10636664738.0
  npm install @tokenami/ds@0.0.63--canary.336.10636664738.0
  npm install @tokenami/ts-plugin@0.0.63--canary.336.10636664738.0
  # or 
  yarn add @tokenami/config@0.0.63--canary.336.10636664738.0
  yarn add @tokenami/css@0.0.63--canary.336.10636664738.0
  yarn add @tokenami/dev@0.0.63--canary.336.10636664738.0
  yarn add @tokenami/ds@0.0.63--canary.336.10636664738.0
  yarn add @tokenami/ts-plugin@0.0.63--canary.336.10636664738.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
