### PR TITLE
add light/dark bg color to translucent swatches in intellisense detail

### DIFF
--- a/packages/ts-plugin/src/index.ts
+++ b/packages/ts-plugin/src/index.ts
@@ -240,7 +240,8 @@ function init(modules: { typescript: typeof tslib }) {
 
   const getSortText = (name: string): `$${string}` => {
     const regex = new RegExp(`['"-]|${TokenamiConfig.tokenProperty('')}`, 'g');
-    return `$${name.replace(regex, '')}`;
+    name = name.replace(regex, '').replace(/[0-9]+/g, (m) => m.padStart(6, '0'));
+    return `$${name}`;
   };
 
   /* -----------------------------------------------------------------------------------------------

--- a/packages/ts-plugin/src/index.ts
+++ b/packages/ts-plugin/src/index.ts
@@ -686,7 +686,7 @@ function init(modules: { typescript: typeof tslib }) {
         if (isColorThemeEntry(entryConfig.modeValues)) {
           const description = createColorTokenDescription(entryConfig.modeValues);
           const hex = firstValue
-            ? convertToHex(replaceCssVarsWithFallback(firstValue))
+            ? convertToRgb(replaceCssVarsWithFallback(firstValue))
             : firstValue;
           const docs = { text: `${hex}\n\n${description}`, kind: 'markdown' };
           return { ...common, documentation: [docs, ...originalDocumentation] };
@@ -745,17 +745,20 @@ function init(modules: { typescript: typeof tslib }) {
 
 /* ---------------------------------------------------------------------------------------------- */
 
-function convertToHex(input: string) {
+// we have to use RBG for alpha channel support because the vscode suggestion
+// widget renderer doesn't support 8-digit hex codes
+// https://github.com/microsoft/vscode/blob/9aa46099e12c6b45f41b0451e19389d91990d0ed/src/vs/editor/contrib/suggest/browser/suggestWidgetRenderer.ts#L36
+function convertToRgb(input: string) {
   try {
     const parsed = culori.parse(input);
-    return culori.formatHex8(parsed);
+    return culori.formatRgb(parsed) ?? input;
   } catch {
     return input;
   }
 }
 
 function createColorTokenDescription(modeValues: NonNullable<EntryConfigItem['modeValues']>) {
-  return createDescription(modeValues, (mode, value) => [createSquare(value), mode, value]);
+  return createDescription(modeValues, (mode, value) => [createSquare(value, mode), mode, value]);
 }
 
 function createTokenDescription(modeValues: NonNullable<EntryConfigItem['modeValues']>) {
@@ -775,9 +778,12 @@ function createRow(row: string[]) {
   return row.join(createSquare('transparent') + createSquare('transparent'));
 }
 
-const createSquare = (color: string) => {
+const createSquare = (color: string, mode?: string) => {
+  const rect = (color: string) => `<rect width="10" height="10" x="0" y="0" fill="${color}" />`;
   const fill = replaceCssVarsWithFallback(color);
-  const svg = `<svg width="10" height="10" xmlns="http://www.w3.org/2000/svg"><rect width="10" height="10" x="0" y="0" fill="${fill}" /></svg>`;
+  const bgRect = mode ? rect(mode === 'dark' ? '#000' : '#fff') : '';
+  const foregroundRect = rect(fill);
+  const svg = `<svg width="10" height="10" xmlns="http://www.w3.org/2000/svg">${bgRect}${foregroundRect}</svg>`;
   return `![Image](data:image/svg+xml;base64,${btoa(svg)})`;
 };
 


### PR DESCRIPTION
# Summary

Closes #328

in Radix Colours the alpha colours are supposed to match the associated base colour as close as possible, but with translucency. this PR adds a white/black background behind the colour swatches in the intellisense _detail_ panel depending on theme mode, to demonstrate how the base/alpha colours match.

unfortunately, the swatch in the `getCompletionsAtPosition` widget on the left will accurately display the transparency so how they appear depends on what editor theme is being used—i can't control the swatch rendering there from the TS plugin :(

while i was here i also:

- added some left-padding to the `sortText` for numbers in tokens to make intellisense ordering more intuitive—instead of a `foo1, foo10, foo11` order, it will sort like `foo1, foo2, foo3, ..., foo10, foo11`
- updated the detail to display the `rgba()` colour at top so that the swatch in `getCompletionsAtPosition` on left had the correct translucency. the vscode suggestion renderer doesn't support 8-digit hex codes so was displaying them as solid colours previously.

| BEFORE | AFTER |
| - | - |
| ![CleanShot 2024-08-30 at 22 23 15](https://github.com/user-attachments/assets/5590fb4a-6c67-4487-b799-026bcbcbd466) | ![CleanShot 2024-08-30 at 22 22 18](https://github.com/user-attachments/assets/ce5b2a78-ff04-4f05-9cb1-671f80a7673c) |

## Change Type

<!-- Please indicate the type of change this is -->

- [ ] `documentation`
- [ ] `patch`
- [x] `minor`
- [ ] `major`

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.0.63--canary.337.10639422719.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @tokenami/config@0.0.63--canary.337.10639422719.0
  npm install @tokenami/css@0.0.63--canary.337.10639422719.0
  npm install @tokenami/dev@0.0.63--canary.337.10639422719.0
  npm install @tokenami/ds@0.0.63--canary.337.10639422719.0
  npm install @tokenami/ts-plugin@0.0.63--canary.337.10639422719.0
  # or 
  yarn add @tokenami/config@0.0.63--canary.337.10639422719.0
  yarn add @tokenami/css@0.0.63--canary.337.10639422719.0
  yarn add @tokenami/dev@0.0.63--canary.337.10639422719.0
  yarn add @tokenami/ds@0.0.63--canary.337.10639422719.0
  yarn add @tokenami/ts-plugin@0.0.63--canary.337.10639422719.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
