### PR TITLE
remove unused layers from minified stylesheet

### DIFF
--- a/packages/dev/src/sheet.ts
+++ b/packages/dev/src/sheet.ts
@@ -5,7 +5,7 @@ import * as utils from './utils';
 import * as Supports from './supports';
 import * as log from './log';
 
-const UNUSED_LAYERS_REGEX = /\n\s*@layer[-\w\s,]+;/g;
+const UNUSED_LAYERS_REGEX = /[\n\s]*@layer[^;{]+;/g;
 const DEFAULT_SELECTOR = '[style]';
 const CUSTOM_PROP_PREFIX = '--_';
 const LAYERS = {


### PR DESCRIPTION
# Summary

this wasn't breaking anything but was unnecessarily adding bloat to the minified stylesheet because the regex to clear the unused layers was wrong.

removes these:

![image](https://github.com/user-attachments/assets/7a2a68d6-ad10-4fdd-8c66-fcbdbb61a33b)


## Change Type

<!-- Please indicate the type of change this is -->

- [ ] `documentation`
- [ ] `patch`
- [x] `minor`
- [ ] `major`
