### PR TITLE
prevent esm warning in node 22 projects

### DIFF
--- a/packages/dev/src/utils/index.ts
+++ b/packages/dev/src/utils/index.ts
@@ -1,2 +1,1 @@
 export * from './common';
-export * from './require';

--- a/packages/dev/src/utils/require.ts
+++ b/packages/dev/src/utils/require.ts
@@ -1,3 +1,0 @@
-// @ts-nocheck
-import { createRequire } from 'module';
-export const safeRequire = createRequire(import.meta.url);


### PR DESCRIPTION
# Summary

this warning doesn't appear to have been breaking anything but it can look a little frightening.

honestly, i don't recall why i used the custom `safeRequire` function that was causing it. it was likely a side-effect of when i was struggling with esm vs cjs package setup. ~i'll need to verify this all works okay still in a non-ts project~ all good 🎉 

| BEFORE | AFTER |
| - | - |
| ![CleanShot 2024-09-07 at 17 23 26](https://github.com/user-attachments/assets/f289b9da-a84a-49a0-9259-afe26f0e91ad) | ![CleanShot 2024-09-07 at 17 22 35](https://github.com/user-attachments/assets/223a0271-ccb6-466d-a720-e5a10e0cdbb5) |

## Change Type

<!-- Please indicate the type of change this is -->

- [ ] `documentation`
- [ ] `patch`
- [x] `minor`
- [ ] `major`

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.0.65--canary.345.10752823728.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @tokenami/config@0.0.65--canary.345.10752823728.0
  npm install @tokenami/css@0.0.65--canary.345.10752823728.0
  npm install @tokenami/dev@0.0.65--canary.345.10752823728.0
  npm install @tokenami/ds@0.0.65--canary.345.10752823728.0
  npm install @tokenami/ts-plugin@0.0.65--canary.345.10752823728.0
  # or 
  yarn add @tokenami/config@0.0.65--canary.345.10752823728.0
  yarn add @tokenami/css@0.0.65--canary.345.10752823728.0
  yarn add @tokenami/dev@0.0.65--canary.345.10752823728.0
  yarn add @tokenami/ds@0.0.65--canary.345.10752823728.0
  yarn add @tokenami/ts-plugin@0.0.65--canary.345.10752823728.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
