### PR TITLE
remove stackblitz from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,9 +18,7 @@
 
 https://github.com/tokenami/tokenami/assets/175330/e41bf385-6836-4f51-8731-33ac796d837d
 
-If you prefer to get stuck straight in, give Tokenami a try on [StackBlitz](https://stackblitz.com/~/github.com/tokenami/tokenami-vite?file=src/App.tsx).
-
-For an enhanced dev experience press `CMD+Shift+P` and choose the workspace version of TypeScript. StackBlitz can't match the experience of a local dev environment (no colour swatches in intellisense) but it's a great way to get started.
+If you prefer to get stuck straight in, give the [vite starter](https://github.com/tokenami/tokenami-vite) a try and remember to choose the workspace version of TypeScript.
 
 ## Contents
 


### PR DESCRIPTION
# Summary

removing this because it can be really buggy when new updates are released (caching issues and things) which can make Tokenami look broken when it isn't. it also doesn't prompt user to enable workspace typescript version consistently which adds to how broken things can feel.

## Change Type

<!-- Please indicate the type of change this is -->

- [x] `documentation`
- [ ] `patch`
- [ ] `minor`
- [ ] `major`
