### PR TITLE
make ts plugin error for invalid special chars

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: ./.github/actions/setup-repo
-      - run: pnpm typecheck:ci
+      - run: pnpm typecheck
       - run: pnpm test
 
   size:

--- a/examples/design-system/package.json
+++ b/examples/design-system/package.json
@@ -18,8 +18,7 @@
     "storylite": "pnpm run \"/storylite:/\"",
     "storylite:app": "vite --port=7007 --host=0.0.0.0",
     "storylite:css": "tokenami --output ./src/tokenami.css --watch",
-    "typecheck": "tsc --noEmit",
-    "typecheck:ci": "tsc --noEmit --project tsconfig.ci.json"
+    "typecheck": "tsc --noEmit --project tsconfig.ci.json"
   },
   "dependencies": {
     "@tokenami/css": "workspace:*",

--- a/examples/remix/app/test.tsx
+++ b/examples/remix/app/test.tsx
@@ -35,6 +35,15 @@ export const expectValidResponsiveAndValidSelectorWithInvalidPropertyToError = c
   '--md_hover_boop': 'var(--color_sky1)',
 });
 
+export const expectValidSelectorsWithSpecialCharactersToError = css({
+  // @ts-ignore
+  '--@md_$hover_color': 'var(--color_sky1)',
+});
+
+export const expectValidSelectorsWithArbitrarySelectorToPass = css({
+  '--md_{&:hover}_color': 'var(--color_sky1)',
+});
+
 export const expectValidPropertiesToPass = css({
   '--display': 'block',
 });

--- a/examples/remix/package.json
+++ b/examples/remix/package.json
@@ -9,8 +9,7 @@
     "dev:app": "remix dev",
     "dev:css": "tokenami --watch",
     "start": "remix-serve build",
-    "typecheck": "tsc --noEmit",
-    "typecheck:ci": "tsc --noEmit --project tsconfig.ci.json",
+    "typecheck": "tsc --noEmit --project tsconfig.ci.json",
     "lint": "eslint ."
   },
   "dependencies": {

--- a/examples/remix/public/tokenami.css
+++ b/examples/remix/public/tokenami.css
@@ -252,11 +252,11 @@
     --background-color: initial;
     --hover: initial;
     --hover_background-color: initial;
-    --\{\&\;focus\;hover\}: initial;
-    --\{\&\;focus\;hover\}_background-color: initial;
     --child-para: initial;
     --selection: initial;
     --selection_background-color: initial;
+    --\{\&\;focus\;hover\}: initial;
+    --\{\&\;focus\;hover\}_background-color: initial;
     --border-block-end: initial;
     --border-color: initial;
     --border-radius: initial;
@@ -365,6 +365,11 @@
       --_g44f3h: var(--inline-size__calc) calc(var(--inline-size) * var(--_grid));
       block-size: var(--_1ieen97, var(--block-size, revert-layer));
       --_1ieen97: var(--block-size__calc) calc(var(--block-size) * var(--_grid));
+    }
+  }
+
+  @layer tkl2 {
+    [style] {
       padding-inline: var(--_1od2e5r, var(--padding-inline, revert-layer));
       --_1od2e5r: var(--padding-inline__calc) calc(var(--padding-inline) * var(--_grid));
       padding-block: var(--_esg7el, var(--padding-block, revert-layer));
@@ -374,20 +379,15 @@
     }
   }
 
-  @layer tkl2 {
+  @layer tkl3 {
     [style] {
+      border-block-end: var(--border-block-end, revert-layer);
       --_1mbhke0: var(--padding-block-start__calc) calc(var(--padding-block-start) * var(--_grid));
       --_13f2miu: var(--margin-block-end__calc) calc(var(--margin-block-end) * var(--_grid));
       --_14lv7pp: var(--margin-inline-start__calc) calc(var(--margin-inline-start) * var(--_grid));
       margin-block-end: var(--_13f2miu, var(--margin-block-end, revert-layer));
       margin-inline-start: var(--_14lv7pp, var(--margin-inline-start, revert-layer));
       padding-block-start: var(--_1mbhke0, var(--padding-block-start, revert-layer));
-    }
-  }
-
-  @layer tkl3 {
-    [style] {
-      border-block-end: var(--border-block-end, revert-layer);
     }
   }
 
@@ -432,9 +432,8 @@
       --_10sf9dp: var(--lg) var(--lg_font-family);
       --_9d9ope: var(--xl) var(--xl_font-family);
       --_6j96ia: var(--xxl) var(--xxl_font-family);
-      background-color: var(--_1r7lnia, var(--_1ir0lsg, var(--_1chvnfl, var(--_1fio48, var(--_4dvc60, revert-layer)))));
+      background-color: var(--_1r7lnia, var(--_1ir0lsg, var(--_1chvnfl, var(--_4dvc60, revert-layer))));
       --_4dvc60: var(--hover) var(--hover_background-color);
-      --_1fio48: var(--\{\&\;focus\;hover\}) var(--\{\&\;focus\;hover\}_background-color);
       --_1chvnfl: var(--child-para) var(--child-para_background-color);
       --_1ir0lsg: var(--selection) var(--selection_background-color);
       --_1r7lnia: var(--\{\&\;focus\;hover\}) var(--\{\&\;focus\;hover\}_background-color);
@@ -467,6 +466,11 @@
       --_1n1rrhq: var(--xl_block-size__calc) calc(var(--xl_block-size) * var(--_grid));
       --_1uebu2j: var(--xxl) var(--_m7qn96, var(--xxl_block-size));
       --_m7qn96: var(--xxl_block-size__calc) calc(var(--xxl_block-size) * var(--_grid));
+    }
+  }
+
+  @layer tksl2 {
+    [style], [style] > p, [style*="selection_"]::selection, [style]:after {
       padding-inline: var(--_hvq2vq, revert-layer);
       --_hvq2vq: var(--child-para) var(--_13rhg63, var(--child-para_padding-inline));
       --_13rhg63: var(--child-para_padding-inline__calc) calc(var(--child-para_padding-inline) * var(--_grid));

--- a/package.json
+++ b/package.json
@@ -13,7 +13,6 @@
     "build": "turbo run build --filter=@tokenami/example-design-system...",
     "clean": "pnpm exec rm -rf node_modules .turbo && pnpm -r exec rm -rf node_modules .turbo dist",
     "typecheck": "turbo run typecheck",
-    "typecheck:ci": "turbo run typecheck:ci",
     "test": "turbo run test",
     "test:watch": "turbo run test:watch",
     "size:why": "size-limit --why",

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -29,8 +29,7 @@
   "scripts": {
     "build": "tsup",
     "dev": "tsup --watch",
-    "typecheck": "tsc --noEmit",
-    "typecheck:ci": "tsc --noEmit"
+    "typecheck": "tsc --noEmit"
   },
   "dependencies": {
     "csstype": "^3.1.2"

--- a/packages/config/src/common.ts
+++ b/packages/config/src/common.ts
@@ -33,7 +33,7 @@ const GridValue = {
 type TokenProperty<P extends string = string> = `--${P}`;
 // thanks chat gpt. will match css variable names that start with `--` and optionally
 // include curly brackets (for arbitrary values), while excluding those prefixed with `var(`
-const tokenPropertyRegex = /(?<!var\()--(?:[\w-]+|\{[^\{\}]*\})+/g;
+const tokenPropertyRegex = /(?<!var\()--(?:[^'":{}]+|{&:[^}]*})+/g;
 
 const TokenProperty = {
   safeParse: (input: unknown) => validate<TokenProperty>(tokenPropertyRegex, input),

--- a/packages/css/package.json
+++ b/packages/css/package.json
@@ -30,7 +30,6 @@
     "build": "tsup",
     "dev": "tsup --watch",
     "typecheck": "tsc --noEmit",
-    "typecheck:ci": "tsc --noEmit",
     "test": "vitest --run",
     "test:watch": "vitest"
   },

--- a/packages/dev/package.json
+++ b/packages/dev/package.json
@@ -33,8 +33,7 @@
   "scripts": {
     "build": "tsup",
     "dev": "tsup --watch",
-    "typecheck": "tsc --noEmit",
-    "typecheck:ci": "tsc --noEmit"
+    "typecheck": "tsc --noEmit"
   },
   "devDependencies": {
     "@types/inquirer": "^9.0.7",

--- a/packages/ds/package.json
+++ b/packages/ds/package.json
@@ -29,8 +29,7 @@
   "scripts": {
     "build": "tsup",
     "dev": "tsup --watch",
-    "typecheck": "tsc --noEmit",
-    "typecheck:ci": "tsc --noEmit"
+    "typecheck": "tsc --noEmit"
   },
   "dependencies": {
     "@radix-ui/colors": "^3.0.0",

--- a/packages/ts-plugin/package.json
+++ b/packages/ts-plugin/package.json
@@ -13,8 +13,7 @@
   "scripts": {
     "build": "tsup",
     "dev": "tsup --watch",
-    "typecheck": "tsc --noEmit",
-    "typecheck:ci": "tsc --noEmit"
+    "typecheck": "tsc --noEmit"
   },
   "dependencies": {
     "@tokenami/config": "workspace:*",

--- a/turbo.json
+++ b/turbo.json
@@ -16,10 +16,6 @@
       "cache": false
     },
     "typecheck": {
-      "dependsOn": ["topo"],
-      "outputs": ["node_modules/.cache/tsbuildinfo.json"]
-    },
-    "typecheck:ci": {
       "dependsOn": ["topo"]
     },
     "storylite": {}


### PR DESCRIPTION
# Summary

i noticed i was able to type `--@md_$hover_color` and the ts plugin wasn't erroring. the CI typechecking catches it but you wouldn't spot it during local development—the CI types are widened to handover to the plugin for improved perf there.

## Change Type

<!-- Please indicate the type of change this is -->

- [ ] `documentation`
- [x] `patch`
- [ ] `minor`
- [ ] `major`

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.0.66--canary.349.10847825022.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @tokenami/config@0.0.66--canary.349.10847825022.0
  npm install @tokenami/css@0.0.66--canary.349.10847825022.0
  npm install @tokenami/dev@0.0.66--canary.349.10847825022.0
  npm install @tokenami/ds@0.0.66--canary.349.10847825022.0
  npm install @tokenami/ts-plugin@0.0.66--canary.349.10847825022.0
  # or 
  yarn add @tokenami/config@0.0.66--canary.349.10847825022.0
  yarn add @tokenami/css@0.0.66--canary.349.10847825022.0
  yarn add @tokenami/dev@0.0.66--canary.349.10847825022.0
  yarn add @tokenami/ds@0.0.66--canary.349.10847825022.0
  yarn add @tokenami/ts-plugin@0.0.66--canary.349.10847825022.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
