### PR TITLE
make `css` utility behave more like `tailwind-merge`

### DIFF
--- a/README.md
+++ b/README.md
@@ -446,7 +446,7 @@ interface ButtonProps extends ButtonElementProps, Variants<typeof button> {}
 
 ### TokenamiStyle
 
-Use `TokenamiStyle` to accept the `css` utility as a value for the `style` prop. This prevents errors when `props.style` is used for overrides.
+The `TokenamiStyle` type allows you to extend the `style` prop of your component with Tokenami-specific properties.
 
 ```tsx
 import { type TokenamiStyle, css } from '@tokenami/css';
@@ -456,6 +456,12 @@ interface ButtonProps extends TokenamiStyle<React.ComponentProps<'button'>> {}
 function Button(props: ButtonProps) {
   return <button {...props} style={css({}, props.style)} />;
 }
+```
+
+You can then use the component as usual, overriding styles as needed. Since the component is already typed and integrates the `css` utility internally, you no longer need to use the utility to apply styles:
+
+```tsx
+<Button style={{ '--padding': 4 }} />
 ```
 
 ### Continuous Integration

--- a/examples/remix/app/routes/_index.tsx
+++ b/examples/remix/app/routes/_index.tsx
@@ -92,7 +92,7 @@ export default function Index() {
       >
         Button
       </button>
-      <DS.Button style={css({ '--border-color': 'var(---, red)' })}>Button</DS.Button>
+      <DS.Button style={{ '--border-color': 'var(---, red)' }}>Button</DS.Button>
     </>
   );
 }

--- a/packages/css/src/index.ts
+++ b/packages/css/src/index.ts
@@ -1,14 +1,14 @@
+import type { TokenamiProperties } from '@tokenami/dev';
 import type { TokenamiCSS } from './css';
 
-export type TokenamiStyle<P> = {
-  [K in keyof P]: K extends 'style' ? TokenamiCSS & P[K] : P[K];
+export type TokenamiStyle<P> = Omit<P, 'style'> & {
+  style?: (TokenamiProperties | TokenamiCSS) & ('style' extends keyof P ? P['style'] : {});
 };
 
 export type Variants<T extends (...args: any) => any> = Parameters<T>[0] extends undefined | null
   ? {}
   : NonNullable<Parameters<T>[0]>;
 
-export type { TokenamiCSS, CSS } from './css';
-export type { Config } from '@tokenami/config';
-export { createConfig } from '@tokenami/config';
-export { createCss, css } from './css';
+export type { TokenamiProperties } from '@tokenami/dev';
+export { type Config, createConfig } from '@tokenami/config';
+export { type TokenamiCSS, type CSS, createCss, css } from './css';


### PR DESCRIPTION
# Summary

with this change we no longer have to use the `css` utility everywhere if the component we're styling already uses it internally (similar to how `tailwind-merge` works).

instead, the `css` utility must be used on native elements only so that the correct merging of styles is performed before it reaches the markup. it is fine to use the `css` utility everywhere if preferred, but this helps minimise some runtime. i'll be exploring some separate perf improvements for the `css` utility so that ppl don't need to worry too much about which direction to choose here.

the `TokenamiStyle` type will add the correct `TokenamiProperties` type to the `style` attribute on your component so you can use the component without the `css` utility:

```tsx
<Button style={{ '--padding': 4 }} />
```

see the readme for how to use the `TokenamiStyle` type.

## Change Type

<!-- Please indicate the type of change this is -->

- [ ] `documentation`
- [ ] `patch`
- [x] `minor`
- [ ] `major`

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.0.66--canary.350.10854375080.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @tokenami/config@0.0.66--canary.350.10854375080.0
  npm install @tokenami/css@0.0.66--canary.350.10854375080.0
  npm install @tokenami/dev@0.0.66--canary.350.10854375080.0
  npm install @tokenami/ds@0.0.66--canary.350.10854375080.0
  npm install @tokenami/ts-plugin@0.0.66--canary.350.10854375080.0
  # or 
  yarn add @tokenami/config@0.0.66--canary.350.10854375080.0
  yarn add @tokenami/css@0.0.66--canary.350.10854375080.0
  yarn add @tokenami/dev@0.0.66--canary.350.10854375080.0
  yarn add @tokenami/ds@0.0.66--canary.350.10854375080.0
  yarn add @tokenami/ts-plugin@0.0.66--canary.350.10854375080.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
