### PR TITLE
add nested theme selector support

### DIFF
--- a/packages/config/src/config.ts
+++ b/packages/config/src/config.ts
@@ -35,6 +35,7 @@ type ThemeModes<T = Theme> = { modes?: ThemeMode<T> };
 type ThemeConfig = Theme | ThemeModes;
 type Aliases = Record<string, readonly CSSProperty[]>;
 type PropertiesOptions = readonly ('grid' | ThemeKey)[];
+type Selector = string | string[];
 
 interface Config {
   include: string[];
@@ -42,10 +43,10 @@ interface Config {
   grid?: string;
   globalStyles?: Record<string, CSS.Properties>;
   responsive?: { [atRule: string]: string };
-  selectors?: { [name: string]: string | string[] };
+  selectors?: { [name: string]: Selector };
   keyframes?: { [name: string]: { [step: string]: CSS.Properties } };
   aliases?: Aliases;
-  themeSelector?: (mode: string) => string;
+  themeSelector?: (mode: string) => Selector;
   theme: ThemeConfig;
   properties?: Partial<Record<CSSProperty | (string & {}), PropertiesOptions>>;
 }


### PR DESCRIPTION
# Summary

closes #291

## Change Type

<!-- Please indicate the type of change this is -->

- [ ] `documentation`
- [ ] `patch`
- [x] `minor`
- [ ] `major`

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.0.67--canary.356.11315504423.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @tokenami/config@0.0.67--canary.356.11315504423.0
  npm install @tokenami/css@0.0.67--canary.356.11315504423.0
  npm install @tokenami/dev@0.0.67--canary.356.11315504423.0
  npm install @tokenami/ds@0.0.67--canary.356.11315504423.0
  npm install @tokenami/ts-plugin@0.0.67--canary.356.11315504423.0
  # or 
  yarn add @tokenami/config@0.0.67--canary.356.11315504423.0
  yarn add @tokenami/css@0.0.67--canary.356.11315504423.0
  yarn add @tokenami/dev@0.0.67--canary.356.11315504423.0
  yarn add @tokenami/ds@0.0.67--canary.356.11315504423.0
  yarn add @tokenami/ts-plugin@0.0.67--canary.356.11315504423.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
