### PR TITLE
fix autogenerated `TokenamiProperties` type in `tokenami.env.d.ts`

### DIFF
--- a/packages/ts-plugin/src/index.ts
+++ b/packages/ts-plugin/src/index.ts
@@ -392,7 +392,10 @@ function init(modules: { typescript: typeof tslib }) {
 
     const updatedEnvFileContent = envFileContent.replace(
       /interface TokenamiProperties([^\\{]*){/,
-      `interface TokenamiProperties extends ${customProperties.join(', ')} {`
+      customProperties.length
+        ? `interface TokenamiProperties extends ${customProperties.join(', ')} {`
+        : // if config is updated to remove custom properties, we need to remove the extends clause
+          'interface TokenamiProperties {'
     );
 
     ts.sys.writeFile(envFilePath, updatedEnvFileContent);


### PR DESCRIPTION
# Summary

the typescript plugin was adding `extends {}` to the `TokenamiProperties` in `tokenami.env.d.ts` when there were no custom properties which would cause the types to error.

my bad for forgetting a `.length` check 🙈 

## Change Type

<!-- Please indicate the type of change this is -->

- [ ] `documentation`
- [x] `patch`
- [ ] `minor`
- [ ] `major`

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.0.68--canary.359.11317197206.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @tokenami/config@0.0.68--canary.359.11317197206.0
  npm install @tokenami/css@0.0.68--canary.359.11317197206.0
  npm install @tokenami/dev@0.0.68--canary.359.11317197206.0
  npm install @tokenami/ds@0.0.68--canary.359.11317197206.0
  npm install @tokenami/ts-plugin@0.0.68--canary.359.11317197206.0
  # or 
  yarn add @tokenami/config@0.0.68--canary.359.11317197206.0
  yarn add @tokenami/css@0.0.68--canary.359.11317197206.0
  yarn add @tokenami/dev@0.0.68--canary.359.11317197206.0
  yarn add @tokenami/ds@0.0.68--canary.359.11317197206.0
  yarn add @tokenami/ts-plugin@0.0.68--canary.359.11317197206.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
