### PR TITLE
[ds] use srgb colour hint for linear gradients

### DIFF
--- a/packages/ds/src/index.ts
+++ b/packages/ds/src/index.ts
@@ -16,7 +16,7 @@ const font = <S extends string, L extends string>(fontSize: S, lineHeight: L) =>
   `var(--font-stretch) var(--font-style) var(--font-variant) var(--font-weight) ${fontSize}/${lineHeight} var(--font-family)` as const;
 
 const optionalViaGradient = <T extends string>(direction: T) =>
-  `linear-gradient(${direction}, var(--gradient-from) var(--gradient-from-stop,/**/), var(---via, var(--gradient-to) var(--gradient-to-stop,/**/)));
+  `linear-gradient(${direction} in srgb, var(--gradient-from) var(--gradient-from-stop,/**/), var(---via, var(--gradient-to) var(--gradient-to-stop,/**/)));
   ---via: var(--gradient-via) var(--gradient-via-stop,/**/), var(--gradient-to)` as const;
 
 const fluid = <P extends string, MinPx extends number, MaxPx extends number>(params: {


### PR DESCRIPTION
# Summary

most design tools use the sRGB color space so i've added this hint to make gradient colours match design tools as close as possible. developers are most likely going to be following a design so it is a little jarring when the colours are off.

| BEFORE | AFTER |
| - | - |
| ![CleanShot 2024-10-18 at 13 29 02](https://github.com/user-attachments/assets/a61c3125-5269-4420-8d0d-77fbd0854d8f) | ![CleanShot 2024-10-18 at 13 28 33](https://github.com/user-attachments/assets/656d3c86-02e7-426a-b5f2-fd90395cc9ff) |

## Change Type

<!-- Please indicate the type of change this is -->

- [ ] `documentation`
- [ ] `patch`
- [x] `minor`
- [ ] `major`

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.0.69--canary.362.11403770071.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @tokenami/config@0.0.69--canary.362.11403770071.0
  npm install @tokenami/css@0.0.69--canary.362.11403770071.0
  npm install @tokenami/dev@0.0.69--canary.362.11403770071.0
  npm install @tokenami/ds@0.0.69--canary.362.11403770071.0
  npm install @tokenami/ts-plugin@0.0.69--canary.362.11403770071.0
  # or 
  yarn add @tokenami/config@0.0.69--canary.362.11403770071.0
  yarn add @tokenami/css@0.0.69--canary.362.11403770071.0
  yarn add @tokenami/dev@0.0.69--canary.362.11403770071.0
  yarn add @tokenami/ds@0.0.69--canary.362.11403770071.0
  yarn add @tokenami/ts-plugin@0.0.69--canary.362.11403770071.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
