### PR TITLE
[ds] add high definition gradients with oklch

### DIFF
--- a/packages/ds/README.md
+++ b/packages/ds/README.md
@@ -83,6 +83,28 @@ The design system uses [Radix UI P3 colours](https://www.radix-ui.com/colors) an
 
 A powerful feature of this palette is dark mode by default when applying the appropriate steps in the scale to each use case. Find out more about [how to use the Radix palette](https://www.radix-ui.com/colors/docs/palette-composition/understanding-the-scale) on their website.
 
+### Gradients
+
+Use the `--gradient_to-[t|r|b|l|tr|tl|br|bl]` tokens along with the `--gradient-from` and `--gradient-to` custom properties to apply gradients.
+
+```tsx
+css({
+  '--background-image': 'var(--gradient_to-b)',
+  '--gradient-from': 'var(--color_crimson9)',
+  '--gradient-to': 'var(--color_green10)',
+});
+```
+
+The base gradients use the sRGB colour space to match the behaviour of design tools, but you can use the `--gradient_hd-to-[t|r|b|l|tr|tl|br|bl]` tokens to apply gradients using the OKLCH colour space for a more accurate representation of colour.
+
+```tsx
+css({
+  '--background-image': 'var(--gradient_hd-to-b)',
+  '--gradient-from': 'var(--color_crimson9)',
+  '--gradient-to': 'var(--color_green10)',
+});
+```
+
 ## Right-to-left support
 
 The design system includes right-to-left support out of the box. This means that directional properties like `padding-left` become `padding-inline-start`, and `padding-right` becomes `padding-inline-end`. If you'd like to disable this, remove the respective aliases from your config.

--- a/packages/ds/src/index.ts
+++ b/packages/ds/src/index.ts
@@ -16,7 +16,7 @@ const font = <S extends string, L extends string>(fontSize: S, lineHeight: L) =>
   `var(--font-stretch) var(--font-style) var(--font-variant) var(--font-weight) ${fontSize}/${lineHeight} var(--font-family)` as const;
 
 const optionalViaGradient = <T extends string>(direction: T) =>
-  `linear-gradient(${direction} in srgb, var(--gradient-from) var(--gradient-from-stop,/**/), var(---via, var(--gradient-to) var(--gradient-to-stop,/**/)));
+  `linear-gradient(${direction}, var(--gradient-from) var(--gradient-from-stop,/**/), var(---via, var(--gradient-to) var(--gradient-to-stop,/**/)));
   ---via: var(--gradient-via) var(--gradient-via-stop,/**/), var(--gradient-to)` as const;
 
 const fluid = <P extends string, MinPx extends number, MaxPx extends number>(params: {
@@ -934,14 +934,22 @@ export default createConfig({
       mono: `ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace`,
     },
     gradient: {
-      'to-t': optionalViaGradient('to top'),
-      'to-tr': optionalViaGradient('to top right'),
-      'to-r': optionalViaGradient('to right'),
-      'to-br': optionalViaGradient('to bottom right'),
-      'to-b': optionalViaGradient('to bottom'),
-      'to-bl': optionalViaGradient('to bottom left'),
-      'to-l': optionalViaGradient('to left'),
-      'to-tl': optionalViaGradient('to top left'),
+      'to-t': optionalViaGradient('to top in srgb'),
+      'to-tr': optionalViaGradient('to top right in srgb'),
+      'to-r': optionalViaGradient('to right in srgb'),
+      'to-br': optionalViaGradient('to bottom right in srgb'),
+      'to-b': optionalViaGradient('to bottom in srgb'),
+      'to-bl': optionalViaGradient('to bottom left in srgb'),
+      'to-l': optionalViaGradient('to left in srgb'),
+      'to-tl': optionalViaGradient('to top left in srgb'),
+      'hd-to-t': optionalViaGradient('to top in oklch'),
+      'hd-to-tr': optionalViaGradient('to top right in oklch'),
+      'hd-to-r': optionalViaGradient('to right in oklch'),
+      'hd-to-br': optionalViaGradient('to bottom right in oklch'),
+      'hd-to-b': optionalViaGradient('to bottom in oklch'),
+      'hd-to-bl': optionalViaGradient('to bottom left in oklch'),
+      'hd-to-l': optionalViaGradient('to left in oklch'),
+      'hd-to-tl': optionalViaGradient('to top left in oklch'),
     },
     space: {
       '0': 0,


### PR DESCRIPTION
# Summary

we have `--gradient_to-[t|r|b|l|tr|tl|br|bl]` tokens for sRGB gradients. this introduces `hd` variants for OKLCH versions `--gradient_hd-to-[t|r|b|l|tr|tl|br|bl]`.

| sRGB | OKLCH | 
| - | - | 
| ![CleanShot 2024-10-18 at 13 28 33](https://github.com/user-attachments/assets/883c4926-f135-4cdd-be36-8728fac9a2c0) | ![CleanShot 2024-10-18 at 13 54 40](https://github.com/user-attachments/assets/f8c35343-64c2-4fec-93e3-866902c9fa81) |

## Change Type

<!-- Please indicate the type of change this is -->

- [ ] `documentation`
- [ ] `patch`
- [x] `minor`
- [ ] `major`

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.0.69--canary.363.11404173171.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @tokenami/config@0.0.69--canary.363.11404173171.0
  npm install @tokenami/css@0.0.69--canary.363.11404173171.0
  npm install @tokenami/dev@0.0.69--canary.363.11404173171.0
  npm install @tokenami/ds@0.0.69--canary.363.11404173171.0
  npm install @tokenami/ts-plugin@0.0.69--canary.363.11404173171.0
  # or 
  yarn add @tokenami/config@0.0.69--canary.363.11404173171.0
  yarn add @tokenami/css@0.0.69--canary.363.11404173171.0
  yarn add @tokenami/dev@0.0.69--canary.363.11404173171.0
  yarn add @tokenami/ds@0.0.69--canary.363.11404173171.0
  yarn add @tokenami/ts-plugin@0.0.69--canary.363.11404173171.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
