### PR TITLE
fix arbitrary attribute selectors

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,7 +264,7 @@ Use arbitrary selectors to prototype quickly:
   style={css({
     '--{&:hover}_color': 'var(--color_primary)',
     '--{&:has(:focus)}_border-color': 'var(--color_highlight)',
-    '--{&:[data-state=open]}_border-color': 'var(--color_primary)',
+    '--{&[data-state=open]}_border-color': 'var(--color_primary)',
   })}
 />
 ```

--- a/packages/config/src/common.ts
+++ b/packages/config/src/common.ts
@@ -31,9 +31,9 @@ const GridValue = {
  * -----------------------------------------------------------------------------------------------*/
 
 type TokenProperty<P extends string = string> = `--${P}`;
-// thanks chat gpt. will match css variable names that start with `--` and optionally
-// include curly brackets (for arbitrary values), while excluding those prefixed with `var(`
-const tokenPropertyRegex = /(?<!var\()--(?:[^'":{}]+|{&:[^}]*})+/g;
+// will match css variable names that start with `--` and optionally include curly brackets
+// (for arbitrary values), while excluding those prefixed with `var(`
+const tokenPropertyRegex = /(?<!var\()--(?:[^'":{}]+|{[^}]*})+/g;
 
 const TokenProperty = {
   safeParse: (input: unknown) => validate<TokenProperty>(tokenPropertyRegex, input),


### PR DESCRIPTION
# Summary

fixes #366 

## Change Type

<!-- Please indicate the type of change this is -->

- [ ] `documentation`
- [x] `patch`
- [ ] `minor`
- [ ] `major`

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.0.70--canary.371.11425428434.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @tokenami/config@0.0.70--canary.371.11425428434.0
  npm install @tokenami/css@0.0.70--canary.371.11425428434.0
  npm install @tokenami/dev@0.0.70--canary.371.11425428434.0
  npm install @tokenami/ds@0.0.70--canary.371.11425428434.0
  npm install @tokenami/ts-plugin@0.0.70--canary.371.11425428434.0
  # or 
  yarn add @tokenami/config@0.0.70--canary.371.11425428434.0
  yarn add @tokenami/css@0.0.70--canary.371.11425428434.0
  yarn add @tokenami/dev@0.0.70--canary.371.11425428434.0
  yarn add @tokenami/ds@0.0.70--canary.371.11425428434.0
  yarn add @tokenami/ts-plugin@0.0.70--canary.371.11425428434.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
