### PR TITLE
import `TokenamiProperties` in env file only when used

### DIFF
--- a/examples/design-system/src/button/button.tsx
+++ b/examples/design-system/src/button/button.tsx
@@ -46,4 +46,5 @@ const button = css.compose({
 
 /* ---------------------------------------------------------------------------------------------- */
 
+export type { ButtonProps };
 export { Button };

--- a/packages/dev/stubs/tokenami.env-custom.d.ts
+++ b/packages/dev/stubs/tokenami.env-custom.d.ts
@@ -1,7 +1,9 @@
+import { type TokenProperties } from '@tokenami/dev';
 import config from './tokenami.config';
 
 export type Config = typeof config;
 
 declare module '@tokenami/dev' {
   interface TokenamiConfig extends Config {}
+  interface TokenamiProperties {}
 }


### PR DESCRIPTION
# Summary

closes #367

## Change Type

<!-- Please indicate the type of change this is -->

- [ ] `documentation`
- [ ] `patch`
- [x] `minor`
- [ ] `major`

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.0.70--canary.372.11425674812.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @tokenami/config@0.0.70--canary.372.11425674812.0
  npm install @tokenami/css@0.0.70--canary.372.11425674812.0
  npm install @tokenami/dev@0.0.70--canary.372.11425674812.0
  npm install @tokenami/ds@0.0.70--canary.372.11425674812.0
  npm install @tokenami/ts-plugin@0.0.70--canary.372.11425674812.0
  # or 
  yarn add @tokenami/config@0.0.70--canary.372.11425674812.0
  yarn add @tokenami/css@0.0.70--canary.372.11425674812.0
  yarn add @tokenami/dev@0.0.70--canary.372.11425674812.0
  yarn add @tokenami/ds@0.0.70--canary.372.11425674812.0
  yarn add @tokenami/ts-plugin@0.0.70--canary.372.11425674812.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
