### PR TITLE
prevent duplicate arbitrary selector styles when including third-party stylesheet

### DIFF
--- a/packages/config/src/common.ts
+++ b/packages/config/src/common.ts
@@ -228,6 +228,16 @@ function parseProperty<T extends string>(str: T, options?: { escapeSpecialChars?
   return noColon.replace(escapeSpecialCharsRegex, (match) => `\\${match}`) as T;
 }
 
+/* -------------------------------------------------------------------------------------------------
+ * stringifyProperty
+ * -------------------------------------------------------------------------------------------------
+ * undo parseProperty
+ * -----------------------------------------------------------------------------------------------*/
+
+function stringifyProperty<T extends string>(property: T) {
+  return decodeColon(property).replace(/\\/g, '') as T;
+}
+
 /* ---------------------------------------------------------------------------------------------- */
 
 const encodeColon = (str: string) => str.replace(/:/g, ';');
@@ -251,6 +261,7 @@ export {
   parsedTokenProperty,
   parsedVariantProperty,
   parseProperty,
+  stringifyProperty,
   getTokenPropertyName,
   getTokenPropertySplit,
   getTokenPropertyParts,

--- a/packages/dev/src/cli.ts
+++ b/packages/dev/src/cli.ts
@@ -192,8 +192,9 @@ async function findUsedTokens(cwd: string, config: Tokenami.Config): Promise<Use
 const CSS_VARIABLE_REGEX = /--(?:[\w-]+|\{[^\{\}]*\})+/g;
 
 function matchTokens(content: string, theme: Tokenami.Config['theme']) {
-  const matches = Array.from(content.replace(/\\/g, '').match(CSS_VARIABLE_REGEX) || []);
-  const uniqueMatches = utils.unique(matches);
+  const matches = content.match(CSS_VARIABLE_REGEX) || [];
+  const stringMatches = Array.from(matches).map(Tokenami.stringifyProperty);
+  const uniqueMatches = utils.unique(stringMatches);
   const variableMatches = uniqueMatches.filter((match) => match !== Tokenami.gridProperty());
 
   const values = variableMatches.flatMap((match) => {


### PR DESCRIPTION
# Summary

if a config has a third-party stylesheet in its `includes`, the third-party stylesheet might include styles like `--\{\&\;focus\;hover\}_background-color: initial`. this fixes a bug where that scenario would result in the sheet generating styles for that property twice if the consumer project also used the same arbitrary selector.

## Change Type

<!-- Please indicate the type of change this is -->

- [ ] `documentation`
- [x] `patch`
- [ ] `minor`
- [ ] `major`

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.0.70--canary.374.11427966507.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @tokenami/config@0.0.70--canary.374.11427966507.0
  npm install @tokenami/css@0.0.70--canary.374.11427966507.0
  npm install @tokenami/dev@0.0.70--canary.374.11427966507.0
  npm install @tokenami/ds@0.0.70--canary.374.11427966507.0
  npm install @tokenami/ts-plugin@0.0.70--canary.374.11427966507.0
  # or 
  yarn add @tokenami/config@0.0.70--canary.374.11427966507.0
  yarn add @tokenami/css@0.0.70--canary.374.11427966507.0
  yarn add @tokenami/dev@0.0.70--canary.374.11427966507.0
  yarn add @tokenami/ds@0.0.70--canary.374.11427966507.0
  yarn add @tokenami/ts-plugin@0.0.70--canary.374.11427966507.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
