### PR TITLE
fix arbitrary selectors for descendant elements 

### DIFF
--- a/packages/config/src/common.ts
+++ b/packages/config/src/common.ts
@@ -129,7 +129,7 @@ function getTokenPropertyName(property: TokenProperty) {
  * -----------------------------------------------------------------------------------------------*/
 
 // split on underscores that aren't inside curly brackets (arbitrary selectors)
-const propertySplitRegex = /_(?![^{}]*\])/;
+const propertySplitRegex = /_(?![^{}]*})/;
 
 function getTokenPropertySplit(property: TokenProperty) {
   const name = getTokenPropertyName(property);


### PR DESCRIPTION
# Summary

#376 raises two issues, this fixes the arbitrary selector support for descendant selectors. it was already implemented but looks like the regex wasn't quite right. 

## Change Type

<!-- Please indicate the type of change this is -->

- [ ] `documentation`
- [x] `patch`
- [ ] `minor`
- [ ] `major`
