### PR TITLE
use .js imports in generated env file to support nodenext envs

### DIFF
--- a/examples/design-system/.tokenami/tokenami.env.d.ts
+++ b/examples/design-system/.tokenami/tokenami.env.d.ts
@@ -1,5 +1,5 @@
 import { type TokenProperties } from '@tokenami/dev';
-import config from './tokenami.config';
+import config from './tokenami.config.js';
 
 export type Config = typeof config;
 

--- a/examples/remix/.tokenami/tokenami.env.d.ts
+++ b/examples/remix/.tokenami/tokenami.env.d.ts
@@ -1,5 +1,5 @@
 import { type TokenProperties } from '@tokenami/dev';
-import config from './tokenami.config';
+import config from './tokenami.config.js';
 
 export type Config = typeof config;
 

--- a/packages/dev/stubs/tokenami.env-custom.d.ts
+++ b/packages/dev/stubs/tokenami.env-custom.d.ts
@@ -1,5 +1,5 @@
 import { type TokenProperties } from '@tokenami/dev';
-import config from './tokenami.config';
+import config from './tokenami.config.js';
 
 export type Config = typeof config;
 

--- a/packages/dev/stubs/tokenami.env.d.ts
+++ b/packages/dev/stubs/tokenami.env.d.ts
@@ -1,4 +1,4 @@
-import config from './tokenami.config';
+import config from './tokenami.config.js';
 
 export type Config = typeof config;
 


### PR DESCRIPTION
# Summary

closes #378 

it’s safer and simpler to always add the `.js` extension in the generated imports. adding `.js` will work in both CommonJS and ES module environments, and it avoids potential issues with module resolution when users are in nodenext mode, where omitting the extension would cause errors.

## Change Type

<!-- Please indicate the type of change this is -->

- [ ] `documentation`
- [x] `patch`
- [ ] `minor`
- [ ] `major`

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.0.71--canary.379.11751125586.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @tokenami/config@0.0.71--canary.379.11751125586.0
  npm install @tokenami/css@0.0.71--canary.379.11751125586.0
  npm install @tokenami/dev@0.0.71--canary.379.11751125586.0
  npm install @tokenami/ds@0.0.71--canary.379.11751125586.0
  npm install @tokenami/ts-plugin@0.0.71--canary.379.11751125586.0
  # or 
  yarn add @tokenami/config@0.0.71--canary.379.11751125586.0
  yarn add @tokenami/css@0.0.71--canary.379.11751125586.0
  yarn add @tokenami/dev@0.0.71--canary.379.11751125586.0
  yarn add @tokenami/ds@0.0.71--canary.379.11751125586.0
  yarn add @tokenami/ts-plugin@0.0.71--canary.379.11751125586.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
