### PR TITLE
apply resets to universal selector

### DIFF
--- a/examples/remix/.tokenami/tokenami.config.ts
+++ b/examples/remix/.tokenami/tokenami.config.ts
@@ -14,7 +14,9 @@ export default createConfig({
   },
   selectors: {
     ...designSystemConfig.selectors,
-    'child-para': '& > p',
+    'child-p': '& > p',
+    'prose-p': '& p',
+    'prose-card': '& .card',
   },
   theme: {
     ...designSystemConfig.theme,

--- a/examples/remix/app/root.tsx
+++ b/examples/remix/app/root.tsx
@@ -32,9 +32,9 @@ export default function App() {
           '--flex-direction': 'column',
           '--align-items': 'center',
           '--justify-content': 'center',
-          '--child-para_background-color': 'var(--color_indigo5)',
-          '--child-para_border-radius': 'var(--radii_sm)',
-          '--child-para_px': 2,
+          '--child-p_background-color': 'var(--color_indigo5)',
+          '--child-p_border-radius': 'var(--radii_sm)',
+          '--child-p_px': 2,
         })}
       >
         <DS.Button onClick={() => setTheme((theme) => (theme === 'light' ? 'dark' : 'light'))}>

--- a/examples/remix/app/routes/_index.tsx
+++ b/examples/remix/app/routes/_index.tsx
@@ -71,6 +71,20 @@ export default function Index() {
         </div>
       </div>
 
+      <div
+        style={css({
+          '--prose-p_background-color': 'var(--color_red8)',
+          '--prose-card_background-color': 'var(--color_amber8)',
+          '--my': 10,
+        })}
+      >
+        Testing prose
+        <div className="card">
+          <p>i should be red</p>
+          <span>i should be amber</span>
+        </div>
+      </div>
+
       <button
         style={css({
           '--border-block-end': 'var(---, 1px solid var(--color_amber12))',

--- a/examples/remix/public/tokenami.css
+++ b/examples/remix/public/tokenami.css
@@ -219,10 +219,12 @@
 
   :root, [data-theme="light"] {
     --color_amber12: #4f3422;
+    --color_amber8: #e2a336;
     --color_amber9: #ffc442;
     --color_indigo10: #3358d4;
     --color_indigo5: #d2deff;
     --color_indigo6: #c1d0ff;
+    --color_red8: #eb8e90;
     --color_violet10: #654dc4;
     --color_violet11: #6550b9;
     --color_violet9: #6e56cf;
@@ -233,10 +235,12 @@
   @supports (color: color(display-p3 0 0 0)) {
     :root, [data-theme="light"] {
       --color_amber12: color(display-p3 .294 .208 .145);
+      --color_amber8: color(display-p3 .85 .65 .3);
       --color_amber9: color(display-p3 1 .77 .26);
       --color_indigo10: color(display-p3 .234 .343 .801);
       --color_indigo5: color(display-p3 .831 .87 1);
       --color_indigo6: color(display-p3 .767 .814 .995);
+      --color_red8: color(display-p3 .872 .575 .572);
       --color_violet10: color(display-p3 .381 .306 .741);
       --color_violet11: color(display-p3 .383 .317 .702);
       --color_violet9: color(display-p3 .417 .341 .784);
@@ -246,10 +250,12 @@
 
   [data-theme="dark"] {
     --color_amber12: #ffe7b3;
+    --color_amber8: #8f6424;
     --color_amber9: #ffc442;
     --color_indigo10: #5472e4;
     --color_indigo5: #253974;
     --color_indigo6: #304384;
+    --color_red8: #b54548;
     --color_violet10: #7d66d9;
     --color_violet11: #bba6ff;
     --color_violet9: #6e56cf;
@@ -260,10 +266,12 @@
   @supports (color: color(display-p3 0 0 0)) {
     [data-theme="dark"] {
       --color_amber12: color(display-p3 .984 .909 .726);
+      --color_amber8: color(display-p3 .535 .399 .189);
       --color_amber9: color(display-p3 1 .77 .26);
       --color_indigo10: color(display-p3 .354 .445 .866);
       --color_indigo5: color(display-p3 .163 .22 .439);
       --color_indigo6: color(display-p3 .203 .262 .5);
+      --color_red8: color(display-p3 .659 .298 .297);
       --color_violet10: color(display-p3 .477 .402 .823);
       --color_violet11: color(display-p3 .72 .65 1);
       --color_violet9: color(display-p3 .417 .341 .784);
@@ -271,7 +279,7 @@
     }
   }
 
-  [style] {
+  * {
     --sm: initial;
     --md: initial;
     --lg: initial;
@@ -280,9 +288,11 @@
     --background-color: initial;
     --hover: initial;
     --hover_background-color: initial;
-    --child-para: initial;
+    --child-p: initial;
     --selection: initial;
     --selection_background-color: initial;
+    --prose-p: initial;
+    --prose-card: initial;
     --\{\&\;focus\;hover\}: initial;
     --\{\&\;focus\;hover\}_background-color: initial;
     --border-block-end: initial;
@@ -333,6 +343,7 @@
     --margin-inline: initial;
     --margin-inline-start: initial;
     --border: initial;
+    --margin-block: initial;
     --border-start-start-radius: initial;
     --border-start-end-radius: initial;
     --object-fit: initial;
@@ -404,6 +415,8 @@
       --_esg7el: var(--padding-block__calc) calc(var(--padding-block) * var(--_grid));
       margin-inline: var(--_1uh1ege, var(--margin-inline, revert-layer));
       --_1uh1ege: var(--margin-inline__calc) calc(var(--margin-inline) * var(--_grid));
+      margin-block: var(--_61fkgk, var(--margin-block, revert-layer));
+      --_61fkgk: var(--margin-block__calc) calc(var(--margin-block) * var(--_grid));
     }
   }
 
@@ -427,9 +440,9 @@
   }
 
   @layer tks1 {
-    [style], [style] > p, [style*="selection_"]::selection, [style]:after {
-      border-radius: var(--_18mum7u, var(--_1ckstr7, var(--_1hh3291, var(--_1aut28, var(--_176qpn4, var(--_117pkm7, revert-layer))))));
-      --_18mum7u: var(--child-para) var(--child-para_border-radius);
+    [style], [style] > p, [style*="selection_"]::selection, [style] p, [style] .card, [style]:after {
+      border-radius: var(--_14pll2c, var(--_1ckstr7, var(--_1hh3291, var(--_1aut28, var(--_176qpn4, var(--_117pkm7, revert-layer))))));
+      --_14pll2c: var(--child-p) var(--child-p_border-radius);
       --_117pkm7: var(--sm) var(--sm_border-radius);
       --_176qpn4: var(--md) var(--md_border-radius);
       --_1aut28: var(--lg) var(--lg_border-radius);
@@ -460,17 +473,19 @@
   }
 
   @layer tks2 {
-    [style], [style] > p, [style*="selection_"]::selection, [style]:after {
+    [style], [style] > p, [style*="selection_"]::selection, [style] p, [style] .card, [style]:after {
       font-family: var(--_6j96ia, var(--_9d9ope, var(--_10sf9dp, var(--_1l5j3ql, var(--_1oveq08, revert-layer)))));
       --_1oveq08: var(--sm) var(--sm_font-family);
       --_1l5j3ql: var(--md) var(--md_font-family);
       --_10sf9dp: var(--lg) var(--lg_font-family);
       --_9d9ope: var(--xl) var(--xl_font-family);
       --_6j96ia: var(--xxl) var(--xxl_font-family);
-      background-color: var(--_1r7lnia, var(--_1ir0lsg, var(--_1chvnfl, var(--_4dvc60, revert-layer))));
+      background-color: var(--_1r7lnia, var(--_vro532, var(--_ohlf6, var(--_1ir0lsg, var(--_1pe4evt, var(--_4dvc60, revert-layer))))));
       --_4dvc60: var(--hover) var(--hover_background-color);
-      --_1chvnfl: var(--child-para) var(--child-para_background-color);
+      --_1pe4evt: var(--child-p) var(--child-p_background-color);
       --_1ir0lsg: var(--selection) var(--selection_background-color);
+      --_ohlf6: var(--prose-p) var(--prose-p_background-color);
+      --_vro532: var(--prose-card) var(--prose-card_background-color);
       --_1r7lnia: var(--\{\&\;focus\;hover\}) var(--\{\&\;focus\;hover\}_background-color);
       font-size: var(--_bemlmj, revert-layer);
       --_bemlmj: var(--xxl) var(--xxl_font-size);
@@ -478,7 +493,7 @@
   }
 
   @layer tksl1 {
-    [style], [style] > p, [style*="selection_"]::selection, [style]:after {
+    [style], [style] > p, [style*="selection_"]::selection, [style] p, [style] .card, [style]:after {
       inline-size: var(--_1s1v5hn, var(--_1c1c65v, var(--_19kqniq, var(--_lbmt5u, var(--_3gor0r, revert-layer)))));
       --_3gor0r: var(--sm) var(--_kbghma, var(--sm_inline-size));
       --_kbghma: var(--sm_inline-size__calc) calc(var(--sm_inline-size) * var(--_grid));
@@ -505,10 +520,10 @@
   }
 
   @layer tksl2 {
-    [style], [style] > p, [style*="selection_"]::selection, [style]:after {
-      padding-inline: var(--_hvq2vq, revert-layer);
-      --_hvq2vq: var(--child-para) var(--_13rhg63, var(--child-para_padding-inline));
-      --_13rhg63: var(--child-para_padding-inline__calc) calc(var(--child-para_padding-inline) * var(--_grid));
+    [style], [style] > p, [style*="selection_"]::selection, [style] p, [style] .card, [style]:after {
+      padding-inline: var(--_ok1ujc, revert-layer);
+      --_ok1ujc: var(--child-p) var(--_hd7nnr, var(--child-p_padding-inline));
+      --_hd7nnr: var(--child-p_padding-inline__calc) calc(var(--child-p_padding-inline) * var(--_grid));
     }
   }
 
@@ -553,11 +568,19 @@
   }
 
   [style] > p {
-    --child-para: ;
+    --child-p: ;
   }
 
   [style*="selection_"]::selection {
     --selection: ;
+  }
+
+  [style] p {
+    --prose-p: ;
+  }
+
+  [style] .card {
+    --prose-card: ;
   }
 
   [style]:focus:hover {


### PR DESCRIPTION
# Summary

closes #376

this fixes the remaining issue in the ticket where descendant selector styles were being inherited due to missing resets. take the following example with `& p` and `& .card` selectors defined in config. before this fix, the `p` would have been amber.

```tsx
<div
  style={css({
    '--prose-p_background-color': 'var(--color_red8)',
    '--prose-card_background-color': 'var(--color_amber8)',
  })}
>
  <div className="card">
    <p>i should be red</p>
    <span>i should be amber</span>
  </div>
</div>
```

to fix, i've moved the css var resets to the universal selector. i also added an error if consumer tries to define a selector without an ampersand in it which will show the error in command line, and in the browser:

![CleanShot 2024-11-09 at 21 08 35](https://github.com/user-attachments/assets/f4c5def8-04fd-4f1d-a813-2b38901d501c)

## Change Type

<!-- Please indicate the type of change this is -->

- [ ] `documentation`
- [x] `patch`
- [ ] `minor`
- [ ] `major`

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.0.72--canary.381.11759504437.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @tokenami/config@0.0.72--canary.381.11759504437.0
  npm install @tokenami/css@0.0.72--canary.381.11759504437.0
  npm install @tokenami/dev@0.0.72--canary.381.11759504437.0
  npm install @tokenami/ds@0.0.72--canary.381.11759504437.0
  npm install @tokenami/ts-plugin@0.0.72--canary.381.11759504437.0
  # or 
  yarn add @tokenami/config@0.0.72--canary.381.11759504437.0
  yarn add @tokenami/css@0.0.72--canary.381.11759504437.0
  yarn add @tokenami/dev@0.0.72--canary.381.11759504437.0
  yarn add @tokenami/ds@0.0.72--canary.381.11759504437.0
  yarn add @tokenami/ts-plugin@0.0.72--canary.381.11759504437.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
