### PR TITLE
fix escaping override in consumer codebases

### DIFF
--- a/packages/css/src/css.ts
+++ b/packages/css/src/css.ts
@@ -72,12 +72,15 @@ type CreateCssOptions = {
   escapeSpecialChars?: boolean;
 };
 
-function createCss(config: Pick<Tokenami.Config, 'aliases'>, options?: CreateCssOptions) {
-  (globalThis as any)[_TOKENAMI_CSS] = options || {};
-  const globalOptions: CreateCssOptions = (globalThis as any)[_TOKENAMI_CSS];
+function createCss(
+  config: Pick<Tokenami.Config, 'aliases'>,
+  options: CreateCssOptions = { escapeSpecialChars: true }
+) {
+  (globalThis as any)[_TOKENAMI_CSS] = options;
 
   const css: CSS = (baseStyles, ...overrides) => {
     let overriddenStyles = {} as TokenamiCSS;
+    const globalOptions = (globalThis as any)[_TOKENAMI_CSS];
     const cacheId = JSON.stringify({ baseStyles, overrides });
     const cached = cache.get(cacheId);
 
@@ -198,7 +201,7 @@ function convertToMediaStyles(bp: string, styles: TokenamiProperties): TokenamiP
 
 /* ---------------------------------------------------------------------------------------------- */
 
-const css = createCss({}, { escapeSpecialChars: true });
+const css = createCss({});
 
 export type { TokenamiCSS, CSS };
 export { createCss, css, convertToMediaStyles };


### PR DESCRIPTION
# Summary

if a design system is built using vite, it needs `escapeSpecialChars: false` to prevent tokenami from escaping the arb selectors in the `style` attribute because vite already escapes them (double-escaping would break the style rules). 

when a project consumes a design system that has used `escapeSpecialChars: false`, it must override that by default unless explicitly switched off by the consuming project. i noticed the override wasn't working, so the remix example project was putting unescaped selectors in the style attribute which didn't work. this fixes that.

## Change Type

<!-- Please indicate the type of change this is -->

- [ ] `documentation`
- [x] `patch`
- [ ] `minor`
- [ ] `major`
