### PR TITLE
[ds] fix `webkit-search-decoration` pseudo-element selector

### DIFF
--- a/packages/ds/src/index.ts
+++ b/packages/ds/src/index.ts
@@ -187,7 +187,7 @@ export default createConfig({
     '::-webkit-inner-spin-button, ::-webkit-outer-spin-button': {
       height: 'auto',
     },
-    '::webkit-search-decoration': {
+    '::-webkit-search-decoration': {
       WebkitAppearance: 'none',
     },
     summary: {


### PR DESCRIPTION
# Summary

When using Next.js it warned me that this selector is not recognized as a valid pseudo-element. At first I ignored it but it seems that their parser is actually right 😄 

![image](https://github.com/user-attachments/assets/94f4753d-75ac-401c-803e-79b5471dddb4)

Checked the TailwindCSS preflight source and it seems like there must have been some error when copying/tweaking

https://github.com/tailwindlabs/tailwindcss/blob/d0b0375d00994bac8caa6364bcbf1ff12944a40c/packages/tailwindcss/preflight.css#L308

## Change Type

- [ ] `documentation`
- [x] `patch`
- [ ] `minor`
- [ ] `major`
