### PR TITLE
allow forked prs to run approved canary builds

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,7 +1,7 @@
 name: build
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, synchronize, reopened]
 
 concurrency:
@@ -11,8 +11,12 @@ concurrency:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v3
+      with:
+          ref: ${{ github.event.pull_request.head.sha }}
       - uses: ./.github/actions/setup-repo
       - run: pnpm typecheck
       - run: pnpm test

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         with:
-          token: ${{ secrets.AUTO_PAT }}
+          token: ${{ secrets.AUTO_PAT_PROD }}
       - run: git fetch --unshallow --tags
       - uses: ./.github/actions/setup-repo
       - run: pnpm build


### PR DESCRIPTION
# Summary

a recent contribution failed the canary build https://github.com/tokenami/tokenami/pull/397

this should allow approved canary builds to proceed.

## Change Type

<!-- Please indicate the type of change this is -->

- [ ] `documentation`
- [ ] `patch`
- [ ] `minor`
- [ ] `major`
