### PR TITLE
fix missing default css export

### DIFF
--- a/packages/css/src/index.ts
+++ b/packages/css/src/index.ts
@@ -11,4 +11,4 @@ export type Variants<T extends (...args: any) => any> = Parameters<T>[0] extends
 
 export type { TokenamiProperties } from 'tokenami';
 export { type Config, createConfig } from '@tokenami/config';
-export { type TokenamiCSS, createCss } from './css';
+export { type TokenamiCSS, createCss, css } from './css';


### PR DESCRIPTION
# Summary

this was missing, which means people will have gotten stuck immediately in the get started docs unless they figured out to use the `createCss` utility themselves. 

## Change Type

<!-- Please indicate the type of change this is -->

- [ ] `documentation`
- [x] `patch`
- [ ] `minor`
- [ ] `major`

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.0.81--canary.424.13995587941.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @tokenami/config@0.0.81--canary.424.13995587941.0
  npm install @tokenami/css@0.0.81--canary.424.13995587941.0
  npm install @tokenami/ds@0.0.81--canary.424.13995587941.0
  npm install tokenami@0.0.81--canary.424.13995587941.0
  # or 
  yarn add @tokenami/config@0.0.81--canary.424.13995587941.0
  yarn add @tokenami/css@0.0.81--canary.424.13995587941.0
  yarn add @tokenami/ds@0.0.81--canary.424.13995587941.0
  yarn add tokenami@0.0.81--canary.424.13995587941.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
