### PR TITLE
improve intellisense details in zed

### DIFF
--- a/packages/tokenami/src/ts-plugin/plugin.ts
+++ b/packages/tokenami/src/ts-plugin/plugin.ts
@@ -389,7 +389,12 @@ function getUnquotedString(name: string) {
  * -------------------------------------------------------------------------------------------*/
 
 function createColorTokenDescription(modeValues: ModeValues) {
-  return createDescription(modeValues, (mode, value) => [createSquare(value, mode), mode, value]);
+  const entries = Object.entries(modeValues);
+  const rows = entries.map(([mode, value]) => {
+    const swatch = createSquare(value, mode);
+    return `${swatch}&nbsp;&nbsp;${mode}&nbsp;&nbsp;&nbsp;&nbsp;${value}`;
+  });
+  return rows.join('\n\n');
 }
 
 /* ---------------------------------------------------------------------------------------------
@@ -397,20 +402,8 @@ function createColorTokenDescription(modeValues: ModeValues) {
  * -------------------------------------------------------------------------------------------*/
 
 function createTokenDescription(modeValues: ModeValues) {
-  return createDescription(modeValues, (mode, value) => [mode, value]);
-}
-
-/* ---------------------------------------------------------------------------------------------
- * createDescription
- * -------------------------------------------------------------------------------------------*/
-
-function createDescription(
-  modeValues: ModeValues,
-  builder: (mode: string, value: string) => string[]
-) {
   const entries = Object.entries(modeValues);
-  const rows = entries.map(([mode, value]) => createRow(builder(mode, value)));
-  return rows.join(`\n\n`);
+  return entries.map(([mode, value]) => `${mode}&nbsp;&nbsp;&nbsp;&nbsp;${value}`).join('\n\n');
 }
 
 /* ---------------------------------------------------------------------------------------------
@@ -420,15 +413,7 @@ function createDescription(
 function createSquare(color: string, mode?: string) {
   const fill = convertToRgb(replaceCssVarsWithFallback(color), mode);
   const svg = `<svg width="10" height="10" xmlns="http://www.w3.org/2000/svg"><rect width="10" height="10" x="0" y="0" fill="${fill}" /></svg>`;
-  return `![Image](data:image/svg+xml;base64,${btoa(svg)})`;
-}
-
-/* ---------------------------------------------------------------------------------------------
- * createRow
- * -------------------------------------------------------------------------------------------*/
-
-function createRow(row: string[]) {
-  return row.join(createSquare('transparent') + createSquare('transparent'));
+  return `![](data:image/svg+xml;base64,${btoa(svg)})`;
 }
 
 /* ---------------------------------------------------------------------------------------------

--- a/packages/tokenami/src/ts-plugin/plugin.ts
+++ b/packages/tokenami/src/ts-plugin/plugin.ts
@@ -192,7 +192,7 @@ class TokenamiPlugin {
       return createEntryDetails(original, entry, `${rgb}\n\n${colorDescription}`);
     } else {
       const description = createTokenDescription(entry.details.modeValues);
-      return createEntryDetails(original, entry, `${firstValue}\n\n${description}`);
+      return createEntryDetails(original, entry, description);
     }
   }
 


### PR DESCRIPTION
# Summary

unfortunately, the markdown SVG swatches alongside each theme mode don't work in Zed, but this is an improvement.

| BEFORE | AFTER |
| - | - | 
| ![CleanShot 2025-03-21 at 17 06 58](https://github.com/user-attachments/assets/3a2a56eb-0a35-4338-bb26-ec888b60af23) | ![CleanShot 2025-03-21 at 17 13 20](https://github.com/user-attachments/assets/9e5f9d4b-879d-4626-8aea-66078e61db2d) |

## Change Type

<!-- Please indicate the type of change this is -->

- [ ] `documentation`
- [ ] `patch`
- [ ] `minor`
- [ ] `major`

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.0.81--canary.425.13997052649.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @tokenami/config@0.0.81--canary.425.13997052649.0
  npm install @tokenami/css@0.0.81--canary.425.13997052649.0
  npm install @tokenami/ds@0.0.81--canary.425.13997052649.0
  npm install tokenami@0.0.81--canary.425.13997052649.0
  # or 
  yarn add @tokenami/config@0.0.81--canary.425.13997052649.0
  yarn add @tokenami/css@0.0.81--canary.425.13997052649.0
  yarn add @tokenami/ds@0.0.81--canary.425.13997052649.0
  yarn add tokenami@0.0.81--canary.425.13997052649.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
