### PR TITLE
remove responsive variants api

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,6 @@
   - [CSS utility](#user-content-css-utility)
   - [CSS compose](#user-content-css-compose)
     - [Variants](#user-content-variants)
-    - [Responsive variants](#user-content-responsive-variants)
     - [Extending styles](#user-content-extending-styles)
 - [Design systems](#user-content-design-systems)
   - [Using the official system](#user-content-using-the-official-system)
@@ -395,31 +394,6 @@ Variants are treated like overrides, so appear inline:
 
 ```html
 <div class="tk-abc" style="--background-color: var(--color_blue); --padding: 6;">boop</div>
-```
-
-#### Responsive variants
-
-Want to swap variants at different breakpoints? Use the `responsiveVariants` key instead of `variants`:
-
-```tsx
-const button = css.compose({
-  '--padding': 4,
-
-  responsiveVariants: {
-    size: {
-      small: { '--padding': 2 },
-      large: { '--padding': 6 },
-    },
-  },
-});
-
-function Button(props) {
-  const [cn, css] = button({
-    size: 'small', // Default size
-    medium_size: 'large', // Large at medium breakpoint
-  });
-  return <button {...props} className={cn(props.className)} style={css(props.style)} />;
-}
 ```
 
 #### Extending styles
@@ -817,7 +791,7 @@ Before raising a bug, please check if it's [already in our todo list](https://gi
 A big thanks to:
 
 - [Tailwind V3](https://v3.tailwindcss.com/) for inspiring many of Tokenami's features
-- [Stitches](https://stitches.dev/) for variants and responsive variants inspiration
+- [Stitches](https://stitches.dev/) for variants inspiration
 - [CSS Hooks](https://css-hooks.com/) for custom selectors inspiration
 - [Lightning CSS](https://lightningcss.dev/) for generating the Tokenami stylesheet
 

--- a/examples/design-system/src/button/button.tsx
+++ b/examples/design-system/src/button/button.tsx
@@ -38,7 +38,7 @@ const button = css.compose({
   '--hover_animation': 'var(--anim_wiggle)',
   '--{&:focus:hover}_background-color': 'var(---, red)',
 
-  responsiveVariants: {
+  variants: {
     size: {
       small: {
         '--font': 'var(--text_base)',

--- a/examples/design-system/src/tokenami.css
+++ b/examples/design-system/src/tokenami.css
@@ -239,11 +239,6 @@
     --block-size: initial;
     --transition: initial;
     --hover_animation: initial;
-    --sm: initial;
-    --md: initial;
-    --lg: initial;
-    --xl: initial;
-    --xxl: initial;
   }
 
   @media (hover: hover) and (pointer: fine) {
@@ -254,36 +249,6 @@
 
   [style]:focus:hover, .tk-1ddz3jq:focus:hover {
     --\{\&\;focus\;hover\}: ;
-  }
-
-  @media (min-width: 40rem) {
-    [style] {
-      --sm: ;
-    }
-  }
-
-  @media (min-width: 48rem) {
-    [style] {
-      --md: ;
-    }
-  }
-
-  @media (min-width: 64rem) {
-    [style] {
-      --lg: ;
-    }
-  }
-
-  @media (min-width: 80rem) {
-    [style] {
-      --xl: ;
-    }
-  }
-
-  @media (min-width: 96rem) {
-    [style] {
-      --xxl: ;
-    }
   }
 }
 
@@ -329,12 +294,6 @@
   [style], .tk-1ddz3jq {
     animation: var(--_xgpg9b, revert-layer);
     --_xgpg9b: var(--hover) var(--hover_animation);
-    font: var(--_ka2h5d, var(--_m8xn1c, var(--_5lcl0m, var(--_18nhvf0, var(--_1xfj32v, revert-layer)))));
-    --_1xfj32v: var(--sm) var(--sm_font);
-    --_18nhvf0: var(--md) var(--md_font);
-    --_5lcl0m: var(--lg) var(--lg_font);
-    --_m8xn1c: var(--xl) var(--xl_font);
-    --_ka2h5d: var(--xxl) var(--xxl_font);
   }
 }
 
@@ -343,12 +302,6 @@
     background-color: var(--_aoiy32, var(--_1gqxh9p, revert-layer));
     --_1gqxh9p: var(--hover) var(--hover_background-color);
     --_aoiy32: var(--\{\&\;focus\;hover\}) var(--\{\&\;focus\;hover\}_background-color);
-    font-family: var(--_1afn4yr, var(--_1sjr7ev, var(--_1710xfo, var(--_48u3vv, var(--_dcd1z4, revert-layer)))));
-    --_dcd1z4: var(--sm) var(--sm_font-family);
-    --_48u3vv: var(--md) var(--md_font-family);
-    --_1710xfo: var(--lg) var(--lg_font-family);
-    --_1sjr7ev: var(--xl) var(--xl_font-family);
-    --_1afn4yr: var(--xxl) var(--xxl_font-family);
   }
 }
 

--- a/examples/remix/app/routes/_index.tsx
+++ b/examples/remix/app/routes/_index.tsx
@@ -13,6 +13,7 @@ export default function Index() {
           '--m': 10,
           '--px': 8,
           '--py': 8,
+          '--justify-items': 'center',
           '--md_display': 'flex',
           '--md_p': 0,
           '--md_text-align': 'left',
@@ -132,17 +133,19 @@ const quoteImage = css.compose({
   '--object-fit': 'cover',
   '--border-color': 'var(--color_iris10)',
 
-  responsiveVariants: {
+  variants: {
     variant: {
       circle: {
         '--width': 24,
         '--height': 24,
         '--border-radius': 'var(--radii_full)',
       },
+    },
+    md_variant: {
       fill: {
-        '--width': 'var(---,11rem)',
-        '--height': 'var(--size_auto)',
-        '--border-radius': 'var(--radii_none)',
+        '--md_width': 'var(---,11rem)',
+        '--md_height': 'var(--size_auto)',
+        '--md_border-radius': 'var(--radii_none)',
       },
     },
   },

--- a/examples/remix/public/tokenami.css
+++ b/examples/remix/public/tokenami.css
@@ -297,11 +297,6 @@
   }
 
   * {
-    --sm: initial;
-    --md: initial;
-    --lg: initial;
-    --xl: initial;
-    --xxl: initial;
     --background-color: initial;
     --hover: initial;
     --hover_background-color: initial;
@@ -316,23 +311,12 @@
     --border-block-color: initial;
     --border-inline-color: initial;
     --border-radius: initial;
-    --sm_border-radius: initial;
+    --md: initial;
     --md_border-radius: initial;
-    --lg_border-radius: initial;
-    --xl_border-radius: initial;
-    --xxl_border-radius: initial;
     --inline-size: initial;
-    --sm_inline-size: initial;
     --md_inline-size: initial;
-    --lg_inline-size: initial;
-    --xl_inline-size: initial;
-    --xxl_inline-size: initial;
     --block-size: initial;
-    --sm_block-size: initial;
     --md_block-size: initial;
-    --lg_block-size: initial;
-    --xl_block-size: initial;
-    --xxl_block-size: initial;
     --transition: initial;
     --hover_animation: initial;
     --min-height: initial;
@@ -349,6 +333,7 @@
     --overflow: initial;
     --margin: initial;
     --padding-block: initial;
+    --justify-items: initial;
     --md_padding: initial;
     --padding: initial;
     --after: initial;
@@ -356,6 +341,7 @@
     --md_after: initial;
     --md_after_content: initial;
     --padding-block-start: initial;
+    --xxl: initial;
     --margin-block-end: initial;
     --margin-inline: initial;
     --margin-inline-start: initial;
@@ -366,40 +352,6 @@
     --border-block-width: initial;
     --border-inline-width: initial;
     --object-fit: initial;
-  }
-
-  @media (min-width: 40rem) {
-    [style] {
-      --sm: ;
-    }
-  }
-
-  @media (min-width: 48rem) {
-    [style] {
-      --md: ;
-    }
-
-    [style]:after {
-      --md_after: ;
-    }
-  }
-
-  @media (min-width: 64rem) {
-    [style] {
-      --lg: ;
-    }
-  }
-
-  @media (min-width: 80rem) {
-    [style] {
-      --xl: ;
-    }
-  }
-
-  @media (min-width: 96rem) {
-    [style] {
-      --xxl: ;
-    }
   }
 
   @media (hover: hover) and (pointer: fine) {
@@ -428,8 +380,24 @@
     --\{\&\;focus\;hover\}: ;
   }
 
+  @media (min-width: 48rem) {
+    [style] {
+      --md: ;
+    }
+
+    [style]:after {
+      --md_after: ;
+    }
+  }
+
   [style]:after {
     --after: ;
+  }
+
+  @media (min-width: 96rem) {
+    [style] {
+      --xxl: ;
+    }
   }
 }
 
@@ -466,6 +434,7 @@
     flex-direction: var(--flex-direction, revert-layer);
     align-items: var(--align-items, revert-layer);
     justify-content: var(--justify-content, revert-layer);
+    justify-items: var(--justify-items, revert-layer);
     line-height: var(--line-height, revert-layer);
     font-size: var(--font-size, revert-layer);
     border-start-start-radius: var(--border-start-start-radius, revert-layer);
@@ -527,23 +496,13 @@
 
 @layer tks1 {
   [style], .tk-1ddz3jq, [style] > p, [style] p, [style] .card, .tk-erz9s7, .tk-rychtn, [style]:after {
-    border-radius: var(--_d4svsr, var(--_117fin6, var(--_1lggj5, var(--_rz7plq, var(--_1u7yt41, var(--_1uzw11x, revert-layer))))));
+    border-radius: var(--_d4svsr, var(--_1u7yt41, revert-layer));
     --_d4svsr: var(--child-p) var(--child-p_border-radius);
-    --_1uzw11x: var(--sm) var(--sm_border-radius);
     --_1u7yt41: var(--md) var(--md_border-radius);
-    --_rz7plq: var(--lg) var(--lg_border-radius);
-    --_1lggj5: var(--xl) var(--xl_border-radius);
-    --_117fin6: var(--xxl) var(--xxl_border-radius);
     animation: var(--_xgpg9b, revert-layer);
     --_xgpg9b: var(--hover) var(--hover_animation);
     color: var(--_ez0gpl, var(--_xksefa, revert-layer));
     --_ez0gpl: var(--hover) var(--hover_color);
-    font: var(--_ka2h5d, var(--_m8xn1c, var(--_5lcl0m, var(--_18nhvf0, var(--_1xfj32v, revert-layer)))));
-    --_1xfj32v: var(--sm) var(--sm_font);
-    --_18nhvf0: var(--md) var(--md_font);
-    --_5lcl0m: var(--lg) var(--lg_font);
-    --_m8xn1c: var(--xl) var(--xl_font);
-    --_ka2h5d: var(--xxl) var(--xxl_font);
     display: var(--_1loixh8, revert-layer);
     --_1loixh8: var(--md) var(--md_display);
     text-align: var(--_18hd4n5, revert-layer);
@@ -564,12 +523,6 @@
 
 @layer tks2 {
   [style], .tk-1ddz3jq, [style] > p, [style] p, [style] .card, .tk-erz9s7, .tk-rychtn, [style]:after {
-    font-family: var(--_1afn4yr, var(--_1sjr7ev, var(--_1710xfo, var(--_48u3vv, var(--_dcd1z4, revert-layer)))));
-    --_dcd1z4: var(--sm) var(--sm_font-family);
-    --_48u3vv: var(--md) var(--md_font-family);
-    --_1710xfo: var(--lg) var(--lg_font-family);
-    --_1sjr7ev: var(--xl) var(--xl_font-family);
-    --_1afn4yr: var(--xxl) var(--xxl_font-family);
     background-color: var(--_aoiy32, var(--_134znwc, var(--_nf2ooy, var(--_9t0pqg, var(--_163r6xx, var(--_1gqxh9p, revert-layer))))));
     --_1gqxh9p: var(--hover) var(--hover_background-color);
     --_163r6xx: var(--child-p) var(--child-p_background-color);
@@ -588,28 +541,12 @@
 
 @layer tksl1 {
   [style], .tk-1ddz3jq, [style] > p, [style] p, [style] .card, .tk-erz9s7, .tk-rychtn, [style]:after {
-    inline-size: var(--_16b7m0x, var(--_qp7e3l, var(--_7u3zlp, var(--_1imu60m, var(--_m0lyz7, revert-layer)))));
-    --_m0lyz7: var(--sm) var(--_1guwk2j, var(--sm_inline-size));
-    --_1guwk2j: var(--sm_inline-size__calc) calc(var(--sm_inline-size) * var(--_grid));
+    inline-size: var(--_1imu60m, revert-layer);
     --_1imu60m: var(--md) var(--_1q1n7d5, var(--md_inline-size));
     --_1q1n7d5: var(--md_inline-size__calc) calc(var(--md_inline-size) * var(--_grid));
-    --_7u3zlp: var(--lg) var(--_8v4x7n, var(--lg_inline-size));
-    --_8v4x7n: var(--lg_inline-size__calc) calc(var(--lg_inline-size) * var(--_grid));
-    --_qp7e3l: var(--xl) var(--_lo58cg, var(--xl_inline-size));
-    --_lo58cg: var(--xl_inline-size__calc) calc(var(--xl_inline-size) * var(--_grid));
-    --_16b7m0x: var(--xxl) var(--_14yrv33, var(--xxl_inline-size));
-    --_14yrv33: var(--xxl_inline-size__calc) calc(var(--xxl_inline-size) * var(--_grid));
-    block-size: var(--_1x4i1t1, var(--_jibyp, var(--_131pits, var(--_qqcymk, var(--_1gmoxa2, revert-layer)))));
-    --_1gmoxa2: var(--sm) var(--_1441hym, var(--sm_block-size));
-    --_1441hym: var(--sm_block-size__calc) calc(var(--sm_block-size) * var(--_grid));
+    block-size: var(--_qqcymk, revert-layer);
     --_qqcymk: var(--md) var(--_he48ex, var(--md_block-size));
     --_he48ex: var(--md_block-size__calc) calc(var(--md_block-size) * var(--_grid));
-    --_131pits: var(--lg) var(--_pn0jbf, var(--lg_block-size));
-    --_pn0jbf: var(--lg_block-size__calc) calc(var(--lg_block-size) * var(--_grid));
-    --_jibyp: var(--xl) var(--_13a1hsi, var(--xl_block-size));
-    --_13a1hsi: var(--xl_block-size__calc) calc(var(--xl_block-size) * var(--_grid));
-    --_1x4i1t1: var(--xxl) var(--_10llkw4, var(--xxl_block-size));
-    --_10llkw4: var(--xxl_block-size__calc) calc(var(--xxl_block-size) * var(--_grid));
   }
 }
 

--- a/packages/css/src/test/compose.test.ts
+++ b/packages/css/src/test/compose.test.ts
@@ -1,7 +1,7 @@
 import { describe, beforeEach, it, expect } from 'vitest';
 import { generateClassName } from '@tokenami/config';
 import { hasStyles, hasSomeStyles } from './utils';
-import { css, _COMPOSE, convertToMediaStyles } from '../css';
+import { css, _COMPOSE } from '../css';
 
 /* -------------------------------------------------------------------------------------------------
  * setup
@@ -48,7 +48,7 @@ const linkStyles = Object.freeze({
 
 const button = css.compose({
   ...baseStyles,
-  responsiveVariants: {
+  variants: {
     disabled: { true: disabledStyles, false: enabledStyles },
     type: { primary: primaryStyles, secondary: secondaryStyles },
   },
@@ -126,25 +126,6 @@ describe('css compose', () => {
 
     it<TestContext>('should not include other variant styles', (context) => {
       expect(hasStyles(context.output, disabledStyles)).toBe(false);
-    });
-  });
-
-  describe('when invoked with a responsive variant', () => {
-    beforeEach<TestContext>((context) => {
-      const [, style] = context.button({ md_type: 'secondary' });
-      context.output = style();
-    });
-
-    it<TestContext>('should not include base styles', (context) => {
-      expect(hasStyles(context.output, baseStylesOutput)).toBe(false);
-    });
-
-    it<TestContext>('should not include other variant styles', (context) => {
-      expect(hasStyles(context.output, primaryStyles)).toBe(false);
-    });
-
-    it<TestContext>('should include responsive variant styles', (context) => {
-      expect(hasStyles(context.output, convertToMediaStyles('md', secondaryStyles))).toBe(true);
     });
   });
 

--- a/packages/tokenami/src/cli.ts
+++ b/packages/tokenami/src/cli.ts
@@ -261,9 +261,7 @@ async function findUsedTokens(cwd: string, config: Tokenami.Config): Promise<Use
 
     for (const composeBlock of composeBlocksContents) {
       const ast = acorn.parse(composeBlock, { ecmaVersion: 'latest' });
-      const responsiveProperties = matchResponsiveComposeVariants(ast, config);
       const composeBlockStyles = matchBaseComposeBlocks(ast);
-      tokenProperties = [...tokenProperties, ...responsiveProperties];
       composeBlocks = { ...composeBlocks, ...composeBlockStyles };
     }
 
@@ -344,18 +342,6 @@ function matchTokens(content: string, theme: Tokenami.Config['theme']) {
 }
 
 /* -------------------------------------------------------------------------------------------------
- * matchResponsiveComposeVariants
- * -----------------------------------------------------------------------------------------------*/
-
-function matchResponsiveComposeVariants(ast: acorn.AnyNode, config: Tokenami.Config) {
-  const responsiveVariants = findResponsiveVariantsBlocks(ast);
-  const tokens = matchTokens(JSON.stringify(responsiveVariants), config.theme);
-  return tokens.properties.flatMap((tokenProperty) => {
-    return utils.getResponsivePropertyVariants(tokenProperty, config.responsive);
-  });
-}
-
-/* -------------------------------------------------------------------------------------------------
  * findComposeBlocks
  * -----------------------------------------------------------------------------------------------*/
 
@@ -379,24 +365,6 @@ function findComposeBlocks(node: acorn.AnyNode): acorn.ObjectExpression[] | unde
   });
 
   return result;
-}
-
-/* -------------------------------------------------------------------------------------------------
- * findResponsiveVariantsBlocks
- * -----------------------------------------------------------------------------------------------*/
-
-function findResponsiveVariantsBlocks(node: acorn.AnyNode): acorn.Property | null {
-  let responsiveVariantsNode = null;
-
-  acornWalk.simple(node, {
-    Property(node) {
-      if (node.key.type === 'Identifier' && node.key.name === 'responsiveVariants') {
-        responsiveVariantsNode = node;
-      }
-    },
-  });
-
-  return responsiveVariantsNode;
 }
 
 /* -------------------------------------------------------------------------------------------------

--- a/packages/tokenami/src/utils.ts
+++ b/packages/tokenami/src/utils.ts
@@ -171,20 +171,6 @@ function generateTypeDefs(configPath: string, stubPath = '../stubs/tokenami.env.
 }
 
 /* -------------------------------------------------------------------------------------------------
- * getResponsivePropertyVariants
- * -----------------------------------------------------------------------------------------------*/
-
-function getResponsivePropertyVariants(
-  tokenProperty: Tokenami.TokenProperty,
-  responsive: Tokenami.Config['responsive']
-): Tokenami.VariantProperty[] {
-  return Object.keys(responsive || {}).map((query) => {
-    const name = Tokenami.getTokenPropertyName(tokenProperty);
-    return Tokenami.variantProperty(query, name);
-  });
-}
-
-/* -------------------------------------------------------------------------------------------------
  * getValidProperties
  * -----------------------------------------------------------------------------------------------*/
 
@@ -248,6 +234,5 @@ export {
   getThemeValuesByTokenValues,
   getThemeFromConfig,
   getThemeValuesByThemeMode,
-  getResponsivePropertyVariants,
   unique,
 };


### PR DESCRIPTION
# Summary

closes #419

## Release Notes

the `responsiveVariants` api in `css.compose` has been removed to reduce the size and runtime overhead of the `css` utility. please update to use `variants` instead. while cumbersome, you can implement `responsiveVariants` manually (see [ticket](https://github.com/tokenami/tokenami/issues/419)).

## Change Type

<!-- Please indicate the type of change this is -->

- [ ] `documentation`
- [ ] `patch`
- [ ] `minor`
- [x] `major`

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.0.81--canary.427.13998351394.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @tokenami/config@0.0.81--canary.427.13998351394.0
  npm install @tokenami/css@0.0.81--canary.427.13998351394.0
  npm install @tokenami/ds@0.0.81--canary.427.13998351394.0
  npm install tokenami@0.0.81--canary.427.13998351394.0
  # or 
  yarn add @tokenami/config@0.0.81--canary.427.13998351394.0
  yarn add @tokenami/css@0.0.81--canary.427.13998351394.0
  yarn add @tokenami/ds@0.0.81--canary.427.13998351394.0
  yarn add tokenami@0.0.81--canary.427.13998351394.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
