### PR TITLE
remove symbol keys to fix RSC support

### DIFF
--- a/packages/css/src/test/create.test.ts
+++ b/packages/css/src/test/create.test.ts
@@ -1,6 +1,6 @@
 import { describe, beforeEach, it, expect } from 'vitest';
 import { hasStyles, hasSomeStyles } from './utils';
-import { _COMPOSE, createCss } from '../css';
+import { createCss } from '../css';
 
 /* -------------------------------------------------------------------------------------------------
  * setup
@@ -117,8 +117,7 @@ describe('css returned from createCss', () => {
     });
 
     it<TestContext>('should override correctly', (context) => {
-      const { [_COMPOSE]: _, ...output } = context.output as any;
-      expect(output).toStrictEqual({
+      expect(context.output).toStrictEqual({
         '--padding-left': 20,
         '--padding-right': 20,
         '--padding-left__calc': '/*on*/',

--- a/packages/css/src/test/css.test.ts
+++ b/packages/css/src/test/css.test.ts
@@ -1,5 +1,5 @@
 import { describe, beforeEach, it, expect } from 'vitest';
-import { TokenamiCSS, _COMPOSE, css } from '../css';
+import { TokenamiCSS, css } from '../css';
 
 /* -------------------------------------------------------------------------------------------------
  * tests
@@ -12,9 +12,7 @@ interface TestContext {
 describe('css utility', () => {
   describe('when called with a grid value', () => {
     beforeEach<TestContext>((context) => {
-      const result = css({ '--padding-left': 10 });
-      const { [_COMPOSE]: _, ...styles } = result;
-      context.output = styles;
+      context.output = css({ '--padding-left': 10 });
     });
 
     it<TestContext>('should convert value to calc', (context) => {
@@ -24,9 +22,7 @@ describe('css utility', () => {
 
   describe('when called with a shorthand after a longhand in base styles', () => {
     beforeEach<TestContext>((context) => {
-      const result = css({ '--padding-left': 10, '--padding': 20 });
-      const { [_COMPOSE]: _, ...styles } = result;
-      context.output = styles;
+      context.output = css({ '--padding-left': 10, '--padding': 20 });
     });
 
     it<TestContext>('should keep the shorthand styles only', (context) => {
@@ -36,9 +32,7 @@ describe('css utility', () => {
 
   describe('when called with a non-numeric override', () => {
     beforeEach<TestContext>((context) => {
-      const result = css({ '--padding': 20 }, { '--padding': 'var(---, 30px)' });
-      const { [_COMPOSE]: _, ...styles } = result;
-      context.output = styles;
+      context.output = css({ '--padding': 20 }, { '--padding': 'var(---, 30px)' });
     });
 
     it<TestContext>('should remove calc toggle', (context) => {


### PR DESCRIPTION
# Summary

when the new classes feature was added to the `css.compose` utility, i introduced a symbol on the object returned by the utility which throws in nextjs when passing styles from an RSC because it was no longer a plain serializable object.

this uses a WeakMap instead of a symbol and updates tests to ensure i don't break serializability going forward.

## Change Type

<!-- Please indicate the type of change this is -->

- [ ] `documentation`
- [x] `patch`
- [ ] `minor`
- [ ] `major`

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.0.82--canary.431.14137117559.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @tokenami/example-design-system@0.0.82--canary.431.14137117559.0
  npm install @tokenami/example-remix@0.0.82--canary.431.14137117559.0
  npm install @tokenami/config@0.0.82--canary.431.14137117559.0
  npm install @tokenami/css@0.0.82--canary.431.14137117559.0
  npm install @tokenami/ds@0.0.82--canary.431.14137117559.0
  npm install tokenami@0.0.82--canary.431.14137117559.0
  # or 
  yarn add @tokenami/example-design-system@0.0.82--canary.431.14137117559.0
  yarn add @tokenami/example-remix@0.0.82--canary.431.14137117559.0
  yarn add @tokenami/config@0.0.82--canary.431.14137117559.0
  yarn add @tokenami/css@0.0.82--canary.431.14137117559.0
  yarn add @tokenami/ds@0.0.82--canary.431.14137117559.0
  yarn add tokenami@0.0.82--canary.431.14137117559.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
