### PR TITLE
fix descendant selectors

### DIFF
--- a/packages/tokenami/src/sheet.ts
+++ b/packages/tokenami/src/sheet.ts
@@ -107,7 +107,7 @@ function createSheet(params: {
       if (prop.variant && toggleKey) {
         const responsive = getResponsiveSelectorFromConfig(prop.responsive, params.config);
         const selectorConfig = getPropertyConfigSelector(prop.selector, params.config);
-        const hasCombinator = selectorConfig.some(isCombinatorSelector);
+        const hasChildSelector = selectorConfig.some(isChildSelector);
         const hashedProperty = hashVariantProperty(prop.variant, cssProperty);
         const basePropertyValue = getBasePropertyValue(prop.tokenProperty, prop, false);
         const toggleProperty = Tokenami.parsedTokenProperty(prop.variant);
@@ -121,7 +121,9 @@ function createSheet(params: {
         const declaration = `${propertyPrefix}${cssProperty}: ${declarationValue};`;
 
         styles.reset.add(`${toggleProperty}: initial;`);
-        if (!isInheritable && !hasCombinator) styles.reset.add(`${prop.tokenProperty}: initial;`);
+        if (!isInheritable && !hasChildSelector) {
+          styles.reset.add(`${prop.tokenProperty}: initial;`);
+        }
 
         if (selectorConfig.includes(`&${SELECTION_PSEUDO}`)) {
           styles.selectorsSelection[layer] ??= new Set<string>();
@@ -569,7 +571,15 @@ function isElementSelector(selector = '') {
  * -----------------------------------------------------------------------------------------------*/
 
 function isCombinatorSelector(selector = '') {
-  return /(.+)\s\&|&\s(.+)/.test(selector);
+  return isChildSelector(selector) || /(.+)\s\&/.test(selector);
+}
+
+/* -------------------------------------------------------------------------------------------------
+ * isChildSelector
+ * -----------------------------------------------------------------------------------------------*/
+
+function isChildSelector(selector = '') {
+  return /&\s(.+)/.test(selector);
 }
 
 /* -------------------------------------------------------------------------------------------------


### PR DESCRIPTION
# Summary

a looooong time ago, i introduced a fix for prose selectors where i removed the `initial` reset for the associated selector's vars if the selector styled a child that should inherit e.g. `{ 'prose-p': ['& p'] }`. as part of that change, i broke descendant styles that _should_ reset, e.g. `{ 'dark': ['[data-theme=dark] &'] }` (note the ampersand is a descendant). this fixes that.

## Change Type

<!-- Please indicate the type of change this is -->

- [ ] `documentation`
- [x] `patch`
- [ ] `minor`
- [ ] `major`

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.0.84--canary.433.14139790433.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @tokenami/example-design-system@0.0.84--canary.433.14139790433.0
  npm install @tokenami/example-remix@0.0.84--canary.433.14139790433.0
  npm install @tokenami/config@0.0.84--canary.433.14139790433.0
  npm install @tokenami/css@0.0.84--canary.433.14139790433.0
  npm install @tokenami/ds@0.0.84--canary.433.14139790433.0
  npm install tokenami@0.0.84--canary.433.14139790433.0
  # or 
  yarn add @tokenami/example-design-system@0.0.84--canary.433.14139790433.0
  yarn add @tokenami/example-remix@0.0.84--canary.433.14139790433.0
  yarn add @tokenami/config@0.0.84--canary.433.14139790433.0
  yarn add @tokenami/css@0.0.84--canary.433.14139790433.0
  yarn add @tokenami/ds@0.0.84--canary.433.14139790433.0
  yarn add tokenami@0.0.84--canary.433.14139790433.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
