### PR TITLE
allow minus numbers as values in compose blocks

### DIFF
--- a/packages/tokenami/src/cli.ts
+++ b/packages/tokenami/src/cli.ts
@@ -286,13 +286,25 @@ function matchBaseComposeBlocks(ast: acorn.AnyNode): Record<`.${string}`, Tokena
     let styles: TokenamiProperties | undefined;
 
     for (const tokenProperty of node.properties) {
-      if (
-        tokenProperty.type === 'Property' &&
-        tokenProperty.key.type === 'Literal' &&
-        tokenProperty.value.type === 'Literal'
-      ) {
+      if (tokenProperty.type === 'Property' && tokenProperty.key.type === 'Literal') {
+        let valueExpression = tokenProperty.value;
+        let value: acorn.Literal['value'];
+
+        if (
+          valueExpression.type === 'UnaryExpression' &&
+          valueExpression.operator === '-' &&
+          valueExpression.argument.type === 'Literal' &&
+          valueExpression.argument.value
+        ) {
+          value = -valueExpression.argument.value;
+        } else if (valueExpression.type === 'Literal') {
+          value = valueExpression.value;
+        } else {
+          continue;
+        }
+
         styles ??= {};
-        styles[tokenProperty.key.value as any] = tokenProperty.value.value as any;
+        styles[tokenProperty.key.value as any] = value;
       }
     }
 

--- a/packages/tokenami/src/ts-plugin/diagnostics.ts
+++ b/packages/tokenami/src/ts-plugin/diagnostics.ts
@@ -121,7 +121,12 @@ class TokenamiDiagnostics {
       } else if (
         !ts.isIdentifier(key) &&
         !ts.isStringLiteral(value) &&
-        !ts.isNumericLiteral(value)
+        !ts.isNumericLiteral(value) &&
+        !(
+          ts.isPrefixUnaryExpression(value) &&
+          value.operator === ts.SyntaxKind.MinusToken &&
+          ts.isNumericLiteral(value.operand)
+        )
       ) {
         const start = value.getStart(sourceFile);
         const length = value.getWidth(sourceFile);


### PR DESCRIPTION
# Summary

this was showing diagnostics errors (and not being extracted to styelsheet):

```tsx
const button = css.compose({
  '--ml': -2
});
```

pr fixes that.

## Change Type

<!-- Please indicate the type of change this is -->

- [ ] `documentation`
- [x] `patch`
- [ ] `minor`
- [ ] `major`
