### PR TITLE
allow vendor prefixed properties in alias config

### DIFF
--- a/packages/config/src/config.ts
+++ b/packages/config/src/config.ts
@@ -5,6 +5,10 @@ interface CSSProperties<TLength = (string & {}) | 0, TTime = string & {}>
   extends CSS.StandardPropertiesHyphen<TLength, TTime>,
     CSS.SvgPropertiesHyphen<TLength, TTime> {}
 
+interface CSSPropertiesWithVendor<TLength = (string & {}) | 0, TTime = string & {}>
+  extends CSSProperties<TLength, TTime>,
+    CSS.VendorPropertiesHyphen<TLength, TTime> {}
+
 type CSSProperty = keyof CSSProperties;
 
 type Theme = { [themeKey: string]: { [themeToken: string]: string | number } };
@@ -14,7 +18,7 @@ type ThemeConfig = Theme | ThemeModes;
 type Responsive = { [atRule: string]: string };
 type Selector = string | string[];
 type Selectors = { [name: string]: Selector };
-type Aliases = Record<string, CSSProperty[]>;
+type Aliases = Record<string, (keyof CSSPropertiesWithVendor)[]>;
 type Properties = Partial<Record<CSSProperty | (string & {}), string[]>>;
 type CustomProperties = Record<string, string[]>;
 


### PR DESCRIPTION
# Summary

i found myself wanting to do something like this:

```tsx
export default createConfig({
  aliases: {
    'scrollbar-display': ['-ms-overflow-style', 'scrollbar-width'],
  },
  properties: {
    '-ms-overflow-style': [],
  },
});

css({ '--scollbar-display': 'none' });
```

but the `-ms-overflow-style` value was erroring in the aliases config. this pr allows it.

## Change Type

<!-- Please indicate the type of change this is -->

- [ ] `documentation`
- [ ] `patch`
- [x] `minor`
- [ ] `major`
