### PR TITLE
automatically add colon after quoted completions

### DIFF
--- a/packages/tokenami/src/ts-plugin/completions.ts
+++ b/packages/tokenami/src/ts-plugin/completions.ts
@@ -31,7 +31,7 @@ type ValueCompletionEntries = {
  * -----------------------------------------------------------------------------------------------*/
 
 type TokenamiCompletionsContext = {
-  insertFormatter?: (name: string) => string;
+  insertFormatter?: (name: string, options?: { type: 'value' | 'property' }) => string;
   logger: Logger;
 };
 
@@ -249,7 +249,7 @@ class TokenamiCompletions {
         kind: ts.ScriptElementKind.string,
         kindModifiers: isColorThemeEntry(modeValues) ? 'color' : parts.themeKey,
         sortText: this.#createSortText(`${index}${entryName}`),
-        insertText: this.#ctx.insertFormatter(entryName),
+        insertText: this.#ctx.insertFormatter(entryName, { type: 'value' }),
         labelDetails: { detail: '', description: entryName },
         details: { modeValues, themeKey: parts.themeKey },
       };
@@ -313,12 +313,15 @@ class TokenamiCompletions {
   #createPropertyEntry(name: string, sortText = this.#createSortText(name)): CompletionEntry {
     const kind = ts.ScriptElementKind.memberVariableElement;
     const kindModifiers = ts.ScriptElementKindModifier.optionalModifier;
+    const insertText = this.#ctx.insertFormatter(name, { type: 'property' });
+    const isSnippet = insertText.includes('${');
     return {
       name,
       kind,
       kindModifiers,
       sortText,
-      insertText: this.#ctx.insertFormatter(name),
+      insertText,
+      ...(isSnippet && { isSnippet }),
     };
   }
 }

--- a/packages/tokenami/src/ts-plugin/diagnostics.ts
+++ b/packages/tokenami/src/ts-plugin/diagnostics.ts
@@ -119,6 +119,7 @@ class TokenamiDiagnostics {
       if (ts.isObjectLiteralExpression(value)) {
         return this.#validateComposeConfig(value, sourceFile);
       } else if (
+        value.getText().length > 0 &&
         !ts.isIdentifier(key) &&
         !ts.isStringLiteral(value) &&
         !ts.isNumericLiteral(value) &&

--- a/packages/tokenami/src/ts-plugin/plugin.ts
+++ b/packages/tokenami/src/ts-plugin/plugin.ts
@@ -66,7 +66,7 @@ class TokenamiPlugin {
     this.#ctx = context;
 
     this.#quotedCompletions = new TokenamiCompletions(this.#config, {
-      insertFormatter: (name) => `"${name}"`,
+      insertFormatter: quotedInsertFormatter,
       logger: context.logger,
     });
 
@@ -90,7 +90,7 @@ class TokenamiPlugin {
         this.#ctx.logger.log(`Config changed at ${configPath}}`);
         this.#completions = new TokenamiCompletions(reloadedConfig, this.#ctx);
         this.#quotedCompletions = new TokenamiCompletions(reloadedConfig, {
-          insertFormatter: (name) => `"${name}"`,
+          insertFormatter: quotedInsertFormatter,
           logger: this.#ctx.logger,
         });
         this.#diagnostics = new TokenamiDiagnostics(reloadedConfig, this.#ctx);
@@ -382,6 +382,16 @@ function updateEnvFile(configPath: string, config: TokenamiConfig.Config) {
         );
 
   ts.sys.writeFile(envFilePath, updatedEnvFileContent);
+}
+
+/* -----------------------------------------------------------------------------------------------
+ * quotedInsertFormatter
+ * ---------------------------------------------------------------------------------------------*/
+
+function quotedInsertFormatter(name: string, options?: { type: 'value' | 'property' }) {
+  if (options?.type === 'value') return `"${name}"`;
+  if (name.slice(-1) === '_') return `"${name}\${1}": \${2}`;
+  return `"${name}": \${1}`;
 }
 
 /* -----------------------------------------------------------------------------------------------


### PR DESCRIPTION
# Summary

improves DX speed by automatically adding a colon when autocompleting properties with quotations:

| BEFORE | AFTER |
| - | - |
| <video src="https://github.com/user-attachments/assets/cb928315-ef2d-49e3-9eb9-5a921e070f4f" controls="controls" muted="muted" class="d-block rounded-bottom-2 border-top width-fit" style="max-height:640px; min-height: 200px"></video> | <video src="https://github.com/user-attachments/assets/89de3b1b-e662-4e68-a303-c2b257db87fe" controls="controls" muted="muted" class="d-block rounded-bottom-2 border-top width-fit" style="max-height:640px; min-height: 200px"></video> |

## Change Type

<!-- Please indicate the type of change this is -->

- [ ] `documentation`
- [ ] `patch`
- [x] `minor`
- [ ] `major`

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.0.87--canary.451.18051940203.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @tokenami/example-design-system@0.0.87--canary.451.18051940203.0
  npm install @tokenami/example-nextjs@0.0.87--canary.451.18051940203.0
  npm install @tokenami/example-remix@0.0.87--canary.451.18051940203.0
  npm install @tokenami/config@0.0.87--canary.451.18051940203.0
  npm install @tokenami/css@0.0.87--canary.451.18051940203.0
  npm install @tokenami/ds@0.0.87--canary.451.18051940203.0
  npm install tokenami@0.0.87--canary.451.18051940203.0
  # or 
  yarn add @tokenami/example-design-system@0.0.87--canary.451.18051940203.0
  yarn add @tokenami/example-nextjs@0.0.87--canary.451.18051940203.0
  yarn add @tokenami/example-remix@0.0.87--canary.451.18051940203.0
  yarn add @tokenami/config@0.0.87--canary.451.18051940203.0
  yarn add @tokenami/css@0.0.87--canary.451.18051940203.0
  yarn add @tokenami/ds@0.0.87--canary.451.18051940203.0
  yarn add tokenami@0.0.87--canary.451.18051940203.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
