### PR TITLE
fix percy shots in Safari and Firefox

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -34,7 +34,7 @@ jobs:
           run: pnpm test
         env:
           PERCY_TOKEN: ${{ secrets.PERCY_TOKEN }}
-          PERCY_BRANCH: ${{ github.head_ref || github.ref_name }}
+          PERCY_PULL_REQUEST: ${{ github.event.pull_request.number }}
           CI: true
 
   size:

--- a/tests/tokenami/src/App.tsx
+++ b/tests/tokenami/src/App.tsx
@@ -41,6 +41,7 @@ export default function Index() {
           '--m': 10,
           '--px': 8,
           '--py': 8,
+          '--display': 'grid',
           '--justify-items': 'center',
           '--md_display': 'flex',
           '--md_p': 0,

--- a/turbo.json
+++ b/turbo.json
@@ -12,7 +12,7 @@
       "persistent": true
     },
     "test": {
-      "env": ["CI", "PERCY_TOKEN"]
+      "env": ["CI", "PERCY_TOKEN", "PERCY_BRANCH", "PERCY_PULL_REQUEST"]
     },
     "test:watch": {
       "cache": false


### PR DESCRIPTION
# Summary

it looks like i forgot to add `display: grid` to the `figure` in the tests so they were showing different results in Safari and Chrome and looked like Tokenami had a bug. it turns out that it's just a bug in Safari. it's reproducible here without Tokenami: https://codepen.io/jjenzz/pen/EaPKyLZ


## Change Type

<!-- Please indicate the type of change this is -->

- [ ] `documentation`
- [X] `patch`
- [ ] `minor`
- [ ] `major`
