### PR TITLE
fix autocompletions for overrides

### DIFF
--- a/packages/css/src/index.ts
+++ b/packages/css/src/index.ts
@@ -1,8 +1,8 @@
 import { type TokenamiProperties } from 'tokenami';
-import { type TokenamiCSS, type TokenamiComposeResult, type Variants as CSSVariants } from './css';
+import { type TokenamiCSS, type TokenamiComposeOutput, type Variants as CSSVariants } from './css';
 
 export type TokenamiStyle<P> = P & { style?: TokenamiProperties | TokenamiCSS };
-export type Variants<T> = T extends TokenamiComposeResult<infer V> ? CSSVariants<V> : {};
+export type Variants<T> = T extends TokenamiComposeOutput<infer V> ? CSSVariants<V> : {};
 
 export type { TokenamiProperties, TokenValue } from 'tokenami';
 export { type Config, createConfig } from '@tokenami/config';

--- a/packages/tokenami/src/ts-plugin/plugin.ts
+++ b/packages/tokenami/src/ts-plugin/plugin.ts
@@ -343,7 +343,9 @@ class TokenamiPlugin {
 
     if (!isTokenami) {
       const typeString = checker.typeToString(contextual);
-      isTokenami = typeString.includes('TokenamiProperties');
+      const isTokenamiProperties = typeString.includes('TokenamiProperties');
+      const isTokenamiOverride = typeString.includes('TokenamiOverride');
+      isTokenami = isTokenamiProperties || isTokenamiOverride;
     }
 
     if (isTokenami) this.#isTokenamiObjectCache.set(cacheKey, true);


### PR DESCRIPTION
# Summary

The performance improvements changes broke autocompletions for overrides in the css util. This fixes it. 

## Change Type

<!-- Please indicate the type of change this is -->

- [ ] `documentation`
- [X] `patch`
- [ ] `minor`
- [ ] `major`
