### PR TITLE
fix complex union type error when passing `props.style` as an override

### DIFF
--- a/README.md
+++ b/README.md
@@ -698,7 +698,7 @@ function Button(props: ButtonProps) {
 }
 ```
 
-Now you can pass Tokenami properties directly with proper type checking:
+Now you can pass Tokenami properties directly to the `style` prop with type checking:
 
 ```tsx
 <Button style={{ '--padding': 4 }} />

--- a/packages/css/src/css.ts
+++ b/packages/css/src/css.ts
@@ -7,7 +7,7 @@ const _TOKENAMI_CSS = Symbol.for('@tokenami/css');
 // types to `CSS.PropertiesHyphen` or `CSS.Properties` which doesn't include `--custom-properties`
 type TokenamiCSS = { [_: symbol]: TokenamiProperties };
 type TokenamiCSSResult = Record<string, any>;
-type TokenamiOverride = TokenamiProperties | TokenamiCSS | false | undefined;
+type TokenamiOverride = TokenamiProperties | TokenamiCSS | false | undefined | Record<string, any>;
 type VariantsConfig<T> = { [K in keyof T]: { [V in keyof T[K]]: TokenamiProperties } };
 type VariantNumber<T> = T extends `${infer N extends number}` ? N : T;
 type VariantBoolean<T> = T extends 'true' | 'false' ? boolean : T;


### PR DESCRIPTION
# Summary

if we don't want to use `TokenamiStyle` to type the style prop with tokenami properties, it produced the following error when the style prop is passed as an override:

<img width="2476" height="796" alt="CleanShot 2025-10-03 at 13 40 19@2x" src="https://github.com/user-attachments/assets/289eec98-dcaa-49b2-a2e2-fad613b75c9f" />

this fix allows people to override with the style prop without needing to make the comp styleabe with tokenami properties.

## Change Type

<!-- Please indicate the type of change this is -->

- [ ] `documentation`
- [x] `patch`
- [ ] `minor`
- [ ] `major`
