### PR TITLE
prevent compose block ast parsing errors from killing tokenami process

### DIFF
--- a/packages/tokenami/src/cli.ts
+++ b/packages/tokenami/src/cli.ts
@@ -258,9 +258,11 @@ async function findUsedTokens(cwd: string, config: Tokenami.Config): Promise<Use
     tokenValues = [...tokenValues, ...tokens.values];
 
     for (const composeBlock of composeBlocksContents) {
-      const ast = acorn.parse(composeBlock, { ecmaVersion: 'latest' });
-      const composeBlockStyles = matchBaseComposeBlocks(ast);
-      composeBlocks = { ...composeBlocks, ...composeBlockStyles };
+      try {
+        const ast = acorn.parse(composeBlock, { ecmaVersion: 'latest' });
+        const composeBlockStyles = matchBaseComposeBlocks(ast);
+        composeBlocks = { ...composeBlocks, ...composeBlockStyles };
+      } catch {}
     }
 
     if (fileContent.includes(sheet.LAYERS.COMPONENTS)) {


### PR DESCRIPTION
# Summary

when adding a malformed property assignment to a compose block (e.g. forgetting to add a comma between assignments), the acorn ast parser would throw an error and kill the tokenami process. this catches the error silently so the compose block styles are ignored until rectified.

## Change Type

<!-- Please indicate the type of change this is -->

- [ ] `documentation`
- [x] `patch`
- [ ] `minor`
- [ ] `major`
