### PR TITLE
fix overeager removal of parent pseudo-classes in #467

### DIFF
--- a/packages/tokenami/src/sheet.ts
+++ b/packages/tokenami/src/sheet.ts
@@ -450,7 +450,7 @@ function getPropertySelectors(
   }
 
   const elementSelectors = utils.unique(selectors).map((selector) => {
-    return isPseudoElementSelector(selector) ? selector : selector.replace(/:.+$/, '');
+    return isPseudoElementSelector(selector) ? selector : selector.replace(/:[^ ]+$/, '');
   });
 
   return {


### PR DESCRIPTION
# Summary

pseudo-classes are still removed, but only when they're attached to the current element and not the parent. e.g. [the previous PR](https://github.com/tokenami/tokenami/pull/467) broke `tbody tr:first-child &` selectors because it converted it to `tbody tr`. 

## Change Type

<!-- Please indicate the type of change this is -->

- [ ] `documentation`
- [x] `patch`
- [ ] `minor`
- [ ] `major`
