### PR TITLE
fix compose cache when passed variants as css override

### DIFF
--- a/packages/css/src/css.ts
+++ b/packages/css/src/css.ts
@@ -169,7 +169,7 @@ function createCss(
 function generateCacheId(objs: (object | TokenamiOverride)[]) {
   return JSON.stringify(objs, (_, value) => {
     if (typeof value === 'object' && value !== null && composeStylesMap.has(value)) {
-      return { ...value, ...composeStylesMap.get(value) };
+      return { ...composeStylesMap.get(value), ...value };
     }
     return value;
   });

--- a/tests/css/specs/compose.test.ts
+++ b/tests/css/specs/compose.test.ts
@@ -73,28 +73,29 @@ const buttonIncludes = css.compose({
   },
 });
 
+const icon = css.compose({
+  '--size': 4,
+  variants: {
+    size: {
+      sm: { '--size': 3 },
+      lg: { '--size': 5 },
+    },
+  },
+} as {});
+
 /* -------------------------------------------------------------------------------------------------
  * tests
  * -----------------------------------------------------------------------------------------------*/
 
 interface TestContext {
-  button: typeof button;
-  link: typeof link;
-  buttonIncludes: typeof buttonIncludes;
   className: string;
   output: ReturnType<ReturnType<typeof button>[1]>;
 }
 
 describe('css compose', () => {
-  beforeEach<TestContext>((context) => {
-    context.button = button;
-    context.link = link;
-    context.buttonIncludes = buttonIncludes;
-  });
-
   describe('when invoked without a config', () => {
     beforeEach<TestContext>((context) => {
-      const [cn, style] = context.button();
+      const [cn, style] = button();
       context.output = style();
       context.className = cn();
     });
@@ -110,7 +111,7 @@ describe('css compose', () => {
 
   describe('when invoked with a variant', () => {
     beforeEach<TestContext>((context) => {
-      const [, style] = context.button({ type: 'primary' });
+      const [, style] = button({ type: 'primary' });
       context.output = style();
     });
 
@@ -129,7 +130,7 @@ describe('css compose', () => {
 
   describe('when invoked with style overrides', () => {
     beforeEach<TestContext>((context) => {
-      const [, style] = context.button({ type: 'secondary' });
+      const [, style] = button({ type: 'secondary' });
       context.output = style({ '--color': 'red' } as any, { '--border-color': 'red' } as any);
     });
 
@@ -145,7 +146,7 @@ describe('css compose', () => {
 
   describe('when invoked with shorthand override', () => {
     beforeEach<TestContext>((context) => {
-      const [, style] = context.button({ type: 'secondary' });
+      const [, style] = button({ type: 'secondary' });
       context.output = style(
         { '--padding-left': 10, '--border': '1px dashed' } as any,
         { '--font': 'arial', '--padding': 30 } as any
@@ -174,8 +175,8 @@ describe('css compose', () => {
 
   describe('when invoked with compose override', () => {
     beforeEach<TestContext>((context) => {
-      const [buttonClassName, buttonStyle] = context.button();
-      const [linkClassName, linkStyle] = context.link();
+      const [buttonClassName, buttonStyle] = button();
+      const [linkClassName, linkStyle] = link();
       context.output = buttonStyle(
         css({ '--color': 'red' } as any),
         linkStyle(css({ '--border-color': 'green' } as any))
@@ -206,7 +207,7 @@ describe('css compose', () => {
 
   describe('when providing includes', () => {
     beforeEach<TestContext>((context) => {
-      const [cn, style] = context.buttonIncludes({ disabled: true });
+      const [cn, style] = buttonIncludes({ disabled: true });
       context.output = style();
       context.className = cn();
     });
@@ -225,6 +226,20 @@ describe('css compose', () => {
         '--border-color': 'initial', // inline because it overrides link base style
         '--font-weight': 'normal', // inline because it's a button variant
       });
+    });
+  });
+
+  describe('when used as a css override', () => {
+    it('should respect variant overrides when styles are cached', () => {
+      const [, style1] = icon({ size: 'sm' });
+      const [, style2] = icon({ size: 'lg' });
+      // cache icon styles
+      const output1 = css({}, style1());
+      // should not reuse icon cache
+      const output2 = css({}, style2());
+
+      expect(output1).toEqual({ '--size': 3, '--size__calc': '/*on*/' });
+      expect(output2).toEqual({ '--size': 5, '--size__calc': '/*on*/' });
     });
   });
 });


### PR DESCRIPTION
# Summary

if a `compose` block was used as a `css` override in multiple places and passed different variants, the variants were overwritten with the cached values from first call-site. 

for example:

```tsx
const icon = css.compose({
  '--size': 4,

  variants: {
    size: { 
      sm: { '--size': 3 }, 
      lg: { '--size': 5 } 
    },
  },
});

const [, style1] = icon({ size: 'sm' });
const [, style2] = icon({ size: 'lg' });

// no icon styles in `css` cache yet, so this worked and added styles to cache 
const output1 = css({}, style1());

// icon styles are in `css` cache now, so this reused `--size: 3` and ignored "lg" variant
const output2 = css({}, style2());
```

it's unlikely many wld come across this bcos `compose` is usually used directly on React elements without `css`, and compose automatically composes `props.style` if needed, e.g. `<div style={style2(props.style)}>`. however, this fixes it just in case by ensuring variant styles always override when building the cache key. 

i'd actually come across this when exploring adding a `css` prop jsx pragma for tokenami in react projects.

## Change Type

<!-- Please indicate the type of change this is -->

- [ ] `documentation`
- [x] `patch`
- [ ] `minor`
- [ ] `major`
