### PR TITLE
fix empty selector error

### DIFF
--- a/packages/tokenami/src/sheet.ts
+++ b/packages/tokenami/src/sheet.ts
@@ -284,6 +284,7 @@ class Sheet {
   }
 
   #generateThemeTokens(styleSelector: string | string[]) {
+    if (styleSelector.length === 0) return '';
     const theme = utils.getThemeFromConfig(this.config.theme);
     const rootSelector = this.config.themeSelector('root');
     const gridStyles = `${rootSelector} { ${Tokenami.gridProperty()}: ${this.config.grid}; }`;


### PR DESCRIPTION
# Summary

tokenami does a loose regex for css vars and can match vars that aren't tokenami properties. because of this, if a new project only contains css vars that aren't tokenami vars, the sheet was being generated with empty selectors for theme tokens and falling over. this fixes it :)

## Change Type

<!-- Please indicate the type of change this is -->

- [ ] `documentation`
- [x] `patch`
- [ ] `minor`
- [ ] `major`

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.0.93--canary.477.20251166200.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @tokenami/example-design-system@0.0.93--canary.477.20251166200.0
  npm install @tokenami/example-nextjs@0.0.93--canary.477.20251166200.0
  npm install @tokenami/config@0.0.93--canary.477.20251166200.0
  npm install @tokenami/css@0.0.93--canary.477.20251166200.0
  npm install @tokenami/ds@0.0.93--canary.477.20251166200.0
  npm install tokenami@0.0.93--canary.477.20251166200.0
  # or 
  yarn add @tokenami/example-design-system@0.0.93--canary.477.20251166200.0
  yarn add @tokenami/example-nextjs@0.0.93--canary.477.20251166200.0
  yarn add @tokenami/config@0.0.93--canary.477.20251166200.0
  yarn add @tokenami/css@0.0.93--canary.477.20251166200.0
  yarn add @tokenami/ds@0.0.93--canary.477.20251166200.0
  yarn add tokenami@0.0.93--canary.477.20251166200.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
