### PR TITLE
ensure cjs module interop for ts plugin

### DIFF
--- a/packages/tokenami/package.json
+++ b/packages/tokenami/package.json
@@ -36,6 +36,8 @@
   "scripts": {
     "build": "tsup",
     "dev": "tsup --watch",
+    "test": "vitest --run",
+    "test:watch": "vitest",
     "typecheck": "tsc --noEmit"
   },
   "devDependencies": {
@@ -44,7 +46,8 @@
     "@types/inquirer": "^9.0.7",
     "@types/node": "^20.3.1",
     "tsup": "^8.4.0",
-    "typescript": "^5.1.3"
+    "typescript": "^5.1.3",
+    "vitest": "^0.34.6"
   },
   "dependencies": {
     "@stitches/stringify": "^1.2.8",

--- a/packages/tokenami/src/index.test.ts
+++ b/packages/tokenami/src/index.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect } from 'vitest';
+import { resolve } from 'node:path';
+import { cwd } from 'node:process';
+
+/* -------------------------------------------------------------------------------------------------
+ * TypeScript Plugin CJS Export Tests
+ *
+ * TypeScript plugins are loaded by tsserver using CommonJS require().
+ * The plugin function MUST be exported directly on module.exports (not module.exports.default).
+ *
+ * tsserver loads plugins like this:
+ *   const plugin = require('tokenami');
+ *   const init = plugin({ typescript: ts });
+ *
+ * If the export is wrapped (e.g., module.exports.default), the plugin will fail to load.
+ * -----------------------------------------------------------------------------------------------*/
+
+describe('tokenami CJS export', () => {
+  const cjsPath = resolve(cwd(), 'dist/index.cjs');
+
+  const loadCjsModule = async () => {
+    const module = await import(cjsPath);
+    return module.default;
+  };
+
+  it('should export the plugin function directly on module.exports', async () => {
+    const exported = await loadCjsModule();
+
+    // The export must be a function, not an object with a default property
+    expect(typeof exported).toBe('function');
+  });
+
+  it('should NOT have a default property wrapping the export', async () => {
+    const exported = await loadCjsModule();
+
+    // If there's a default property, the export structure is wrong for TS plugins
+    expect(exported).not.toHaveProperty('default');
+  });
+
+  it('should return a plugin initializer when called with typescript module', async () => {
+    const exported = await loadCjsModule();
+
+    // Mock the typescript module structure that tsserver passes
+    const mockTypescript = {
+      typescript: {
+        sys: {},
+        ScriptKind: {},
+      },
+    };
+
+    // The function should return something (the plugin initializer)
+    // without throwing when given a valid typescript module object
+    const result = exported(mockTypescript);
+
+    expect(result).toBeDefined();
+    expect(typeof result).toBe('object');
+    expect(result).toHaveProperty('create');
+  });
+
+  it('should throw an error when called without typescript module', async () => {
+    const exported = await loadCjsModule();
+
+    expect(() => exported()).toThrow();
+    expect(() => exported({})).toThrow();
+    expect(() => exported(null)).toThrow();
+  });
+});

--- a/packages/tokenami/src/index.ts
+++ b/packages/tokenami/src/index.ts
@@ -1,2 +1,17 @@
 export type * from './declarations';
-export { createTSPlugin as default } from './ts-plugin';
+
+import { createTSPlugin } from './ts-plugin';
+
+interface TypeScriptPluginModule {
+  typescript: typeof import('typescript');
+}
+
+function tokenami(mod: TypeScriptPluginModule) {
+  if (mod && typeof mod === 'object' && 'typescript' in mod) {
+    return createTSPlugin(mod);
+  }
+
+  throw new Error('Tokenami only supports importing types from the root module.');
+}
+
+export default tokenami;

--- a/packages/tokenami/tsconfig.json
+++ b/packages/tokenami/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "../../tsconfig.json",
   "include": ["src", "stubs"],
+  "exclude": ["src/**/*.test.ts"],
   "compilerOptions": {
     "baseUrl": ".",
     "tsBuildInfoFile": "node_modules/.cache/tsbuildinfo.json",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -261,6 +261,9 @@ importers:
       typescript:
         specifier: ^5.1.3
         version: 5.4.5
+      vitest:
+        specifier: ^0.34.6
+        version: 0.34.6(lightningcss@1.29.1)(playwright@1.55.1)
 
   tests/css:
     dependencies:


### PR DESCRIPTION
# Summary

i noticed the ts plugin wasn't working in one of my wip feature branches because i added some named exports from the tokenami module and it broke the cjsinterop behaviour. luckily i spotted this before it made its way into `main` so i've added a more explicit solution with tests to make sure this doesn't accidentally slip in going fwd.

## Change Type

<!-- Please indicate the type of change this is -->

- [ ] `documentation`
- [ ] `patch`
- [ ] `minor`
- [ ] `major`
