### PR TITLE
move canary release to release.yaml

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -50,29 +50,5 @@ jobs:
       - uses: andresz1/size-limit-action@v1
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          # prepare script does this
+          # postinstall script does this
           skip_step: build
-
-  canary:
-    runs-on: ubuntu-latest
-    needs: build
-    if: ${{ github.ref != 'ref/head/main' && !contains(github.event.pull_request.labels.*.name, 'skip-release') }}
-    environment: canary
-    permissions:
-      contents: write
-      pull-requests: write
-      statuses: write
-      checks: write
-      issues: write
-      packages: write
-    env:
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN_CANARY }}
-      NPM_TOKEN: ${{ secrets.NPM_TOKEN_CANARY }}
-    steps:
-      - uses: actions/checkout@v3
-        with:
-          token: ${{ secrets.AUTO_PAT }}
-      - run: git fetch --unshallow --tags
-      - uses: ./.github/actions/setup-repo
-      - run: pnpm release

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -5,10 +5,17 @@ on:
     branches:
       - main
 
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
-  release:
+  production:
+    if: ${{ github.event_name == 'push' && !contains(github.event.head_commit.message, 'ci skip') && !contains(github.event.head_commit.message, 'skip ci') }}
     runs-on: ubuntu-latest
-    if: ${{ !contains(github.event.head_commit.message, 'ci skip') && !contains(github.event.head_commit.message, 'skip ci') }}
     environment: production
     permissions: write-all
     env:
@@ -20,5 +27,27 @@ jobs:
           token: ${{ secrets.AUTO_PAT_PROD }}
       - run: git fetch --unshallow --tags
       - uses: ./.github/actions/setup-repo
-      - run: pnpm build
+      - run: pnpm release
+
+  canary:
+    if: ${{ github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'skip-release') }}
+    runs-on: ubuntu-latest
+    environment: canary
+    permissions:
+      contents: write
+      id-token: write
+      pull-requests: write
+      statuses: write
+      checks: write
+      issues: write
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN_CANARY }}
+      NPM_TOKEN: ${{ secrets.NPM_TOKEN_CANARY }}
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          token: ${{ secrets.AUTO_PAT }}
+      - run: git fetch --unshallow --tags
+      - uses: ./.github/actions/setup-repo
       - run: pnpm release


### PR DESCRIPTION
# Summary

Trusted Publishing only allows one yaml file to be responsible for npm releases, so moving production and canary publishing both into release.yaml.

## Change Type

<!-- Please indicate the type of change this is -->

- [ ] `documentation`
- [ ] `patch`
- [ ] `minor`
- [ ] `major`
