### PR TITLE
improve intellisense perf w/o requiring suggest tuning in settings.json

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -6,7 +6,5 @@
   "typescript.enablePromptUseWorkspaceTsdk": true,
 
   "typescript.tsdk": "node_modules/typescript/lib",
-  "editor.suggest.filterGraceful": false,
-  "editor.suggest.matchOnWordStartOnly": true,
   "editor.quickSuggestions": { "strings": true }
 }

--- a/README.md
+++ b/README.md
@@ -51,7 +51,6 @@
   - [CI setup](#user-content-ci-setup)
 - [Troubleshooting](#user-content-troubleshooting)
   - [Enable string completions](#user-content-enable-string-completions)
-  - [Improve autocomplete speed and accuracy](#user-content-improve-autocomplete-speed-and-accuracy)
   - [Supported libraries](#user-content-supported-libraries)
   - [Supported browsers](#user-content-supported-browsers)
   - [Supported editors](#user-content-supported-editors)
@@ -93,7 +92,7 @@ npx tokenami init
 ```
 
 - Make sure your editor uses the workspace TypeScript version (see [VS Code docs](https://code.visualstudio.com/docs/typescript/typescript-compiling#_using-the-workspace-version-of-typescript)).
-- For VS Code–based editors, [enable string suggestions](#user-content-enable-string-completions) and check our [autocomplete tuning guide](#user-content-improve-autocomplete-speed-and-accuracy).
+- For VS Code–based editors, [enable string suggestions](#user-content-enable-string-completions).
 
 #### 2. Run the watcher to build your CSS:
 
@@ -119,7 +118,7 @@ Benefits include:
 
 - 🏷️ **Simple naming convention** — turn any CSS property into a variable (`padding` → `--padding`)
 - 📦 **Smaller stylesheet** — one variable-driven rule instead of dozens of utility classes
-- ✨ **Streamlined markup** — one class name for your reusable components, keeping HTML clean and DRY
+- ✨ **Streamlined markup** — one class name for your reusable components, keeping HTML lean
 - 🎯 **Single source of truth** — a config file defines and enforces your design tokens
 - 💡 **Smart authoring** — autocomplete + type safety built into your workflow
 - 🔓 **Extensible by design** — atomic CSS variables give your consumers control to override
@@ -127,7 +126,6 @@ Benefits include:
 - ⚡ **Dynamic by default** — pass props directly into tokens (`--color: props.color`)
 - ✍️ **Shorthand tokens** — define aliases like `--p` for padding
 - 🎨 **Expressive selectors** — custom selectors for nesting and descendant rules
-- 🚀 **Zero bundler friction** — static styles with no bundler integration
 
 ### Why Tokenami?
 
@@ -777,20 +775,6 @@ VS Code won't suggest completions for partial strings by default. This prevents 
 | BEFORE                                                                                                               | AFTER                                                                                                                |
 | -------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------- |
 | ![CleanShot 2024-09-08 at 14 10 10](https://github.com/user-attachments/assets/9b99edb4-dec0-402e-99c9-671525332ccf) | ![CleanShot 2024-09-08 at 14 09 43](https://github.com/user-attachments/assets/ad2ed719-c2ca-4929-902d-5fdf5142468b) |
-
-### Improve autocomplete speed and accuracy
-
-Some editors that Tokenami integrates with (such as VS Code and Cursor) support VS Code–style configuration settings. If you feel Tokenami's completions are slow or match on irrelevant suggestions, you can refine IntelliSense behaviour by adding the following settings to your workspace `.vscode/settings.json`:
-
-```json
-{
-  "editor.suggest.filterGraceful": false,
-  "editor.suggest.matchOnWordStartOnly": true
-}
-```
-
-- **"editor.suggest.filterGraceful": false**: Filters out loosely related suggestions so closer matches are shown.
-- **"editor.suggest.matchOnWordStartOnly": true**: Redcues noise by prioritising suggestions that begin with your typed characters.
 
 ### Supported libraries
 

--- a/packages/tokenami/package.json
+++ b/packages/tokenami/package.json
@@ -63,7 +63,6 @@
     "csstype": "^3.1.2",
     "culori": "^4.0.1",
     "fast-glob": "^3.2.12",
-    "find-up": "^4.0.0",
     "inquirer": "^9.2.12",
     "jiti": "^1.21.0",
     "lightningcss": "1.29.1",

--- a/packages/tokenami/src/ts-plugin/completions.ts
+++ b/packages/tokenami/src/ts-plugin/completions.ts
@@ -40,7 +40,6 @@ class TokenamiCompletions {
   #responsiveEntries: [string, string][];
   #base: CompletionEntries;
   #selectorSnippets: SelectorCompletionEntries;
-  #responsiveArbitrarySelectorSnippets: SelectorCompletionEntries;
 
   // lazily instantiate and cache these
   #_responsiveSelectorSnippets?: SelectorCompletionEntries;
@@ -56,7 +55,6 @@ class TokenamiCompletions {
     this.#responsiveEntries = Object.entries(this.#config.responsive || {});
     this.#base = this.#getBaseCompletions();
     this.#selectorSnippets = this.#getSelectorSnippetCompletions();
-    this.#responsiveArbitrarySelectorSnippets = this.#getResponsiveArbitrarySelectorSnippets();
   }
 
   get #responsiveSelectorSnippets() {
@@ -103,7 +101,7 @@ class TokenamiCompletions {
     const parts = TokenamiConfig.getTokenPropertySplit(input as any);
 
     if (!parts.variants.length) {
-      return { ...this.#selectorSnippets, ...this.#responsiveArbitrarySelectorSnippets };
+      return this.#selectorSnippets;
     }
 
     if (parts.variants.length === 1) {
@@ -117,12 +115,6 @@ class TokenamiCompletions {
   #arbitrarySelectorRegex = /\{(.*)\}/;
   #getArbitrarySelector(input: string) {
     return input.match(this.#arbitrarySelectorRegex)?.[1];
-  }
-
-  #getResponsiveArbitrarySelectorSnippets() {
-    const selectorConfig = [[`{}`, '']] as [string, string][];
-    const completions = this.#getResponsiveSelectorSnippetCompletions(selectorConfig);
-    return completions;
   }
 
   #selectorsSearch(input: string, alias: string, variants: string[]) {
@@ -314,10 +306,14 @@ class TokenamiCompletions {
   #createPropertyEntry(name: string, sortText = this.#createSortText(name)): CompletionEntry {
     const kind = ts.ScriptElementKind.memberVariableElement;
     const kindModifiers = ts.ScriptElementKindModifier.optionalModifier;
+    const isSelector = name.slice(-1) === '_';
+    const filterText = isSelector ? name.slice(0, -1) : name;
     const insertText = this.#ctx.insertFormatter(name, { type: 'property' });
     const isSnippet = insertText.includes('${');
+
     return {
       name,
+      filterText,
       kind,
       kindModifiers,
       sortText,

--- a/packages/tokenami/src/ts-plugin/plugin.ts
+++ b/packages/tokenami/src/ts-plugin/plugin.ts
@@ -1,6 +1,4 @@
 import ts from 'typescript/lib/tsserverlibrary.js';
-import * as findUp from 'find-up';
-import * as pathe from 'pathe';
 import * as culori from 'culori';
 import * as TokenamiConfig from '@tokenami/config';
 import * as tokenami from '../utils';
@@ -51,17 +49,11 @@ class TokenamiPlugin {
   #completions: TokenamiCompletions;
   #quotedCompletions: TokenamiCompletions;
   #completionsForPosition: { [entryName: string]: ts.CompletionEntry } | null = null;
-  #isIncompleteCompletions = true;
 
   constructor(configPath: string, context: TokenamiPluginContext) {
-    const projectCwd = context.info.project.getCurrentDirectory();
-    const projectRoot = findProjectRoot(projectCwd);
-    const settingsPath = pathe.join(projectRoot, '.vscode', 'settings.json');
-
     this.#config = tokenami.getConfigAtPath(configPath);
     this.#diagnostics = new TokenamiDiagnostics(this.#config, context);
     this.#completions = new TokenamiCompletions(this.#config, context);
-    this.#isIncompleteCompletions = getIsIncompleteCompletionsSetting(context.ts, settingsPath);
     this.#ctx = context;
 
     this.#quotedCompletions = new TokenamiCompletions(this.#config, {
@@ -141,7 +133,6 @@ class TokenamiPlugin {
         isGlobalCompletion: false,
         isMemberCompletion: false,
         isNewIdentifierLocation: false,
-        ...(this.#isIncompleteCompletions && { isIncomplete: true }),
         optionalReplacementSpan: {
           start: position - rawInput.length,
           length: rawInput.length,
@@ -500,49 +491,6 @@ function convertToRgb(fill: string, mode?: string) {
     return culori.formatRgb(color);
   } catch {
     return fill;
-  }
-}
-
-/* -------------------------------------------------------------------------------------------------
- * getIsIncompleteCompletionsSetting
- * -----------------------------------------------------------------------------------------------*/
-
-function getIsIncompleteCompletionsSetting(tsserver: typeof ts, settingsPath: string): boolean {
-  if (!tsserver.sys.fileExists(settingsPath)) return true;
-
-  const text = tsserver.sys.readFile(settingsPath, 'utf8');
-  if (!text) return true;
-
-  const parsed = tsserver.parseConfigFileTextToJson(settingsPath, text);
-  const json = parsed.config as Record<string, any> | undefined;
-  if (!json) return true;
-
-  const matchOnWordStartOnly = json['editor.suggest.matchOnWordStartOnly'];
-  const filterGraceful = json['editor.suggest.filterGraceful'];
-
-  return matchOnWordStartOnly !== true && filterGraceful !== false;
-}
-
-/* -------------------------------------------------------------------------------------------------
- * findProjectRoot
- * -----------------------------------------------------------------------------------------------*/
-
-const workspaceFiles = ['pnpm-workspace.yaml', 'lerna.json', 'nx.json', 'turbo.json'];
-
-function findProjectRoot(cwd: string): string {
-  try {
-    const wsMarker = findUp.sync(workspaceFiles, { cwd });
-    if (wsMarker) return pathe.dirname(wsMarker);
-
-    const gitDir = findUp.sync('.git', { cwd, type: 'directory' as const });
-    if (gitDir) return pathe.dirname(gitDir);
-
-    const pkg = findUp.sync('package.json', { cwd });
-    if (pkg) return pathe.dirname(pkg);
-
-    return cwd;
-  } catch {
-    return cwd;
   }
 }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -230,9 +230,6 @@ importers:
       fast-glob:
         specifier: ^3.2.12
         version: 3.3.2
-      find-up:
-        specifier: ^4.0.0
-        version: 4.1.0
       inquirer:
         specifier: ^9.2.12
         version: 9.2.23


### PR DESCRIPTION
# Summary

removes the intellisense tuning recommendation:

```json
{
  "editor.suggest.filterGraceful": false,
  "editor.suggest.matchOnWordStartOnly": true
}
```

this is no longer required for improved perf, so you can remove it if you have it :)

## Change Type

<!-- Please indicate the type of change this is -->

- [ ] `documentation`
- [x] `patch`
- [ ] `minor`
- [ ] `major`

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.0.94--canary.489.26465713127.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @tokenami/example-design-system@0.0.94--canary.489.26465713127.0
  npm install @tokenami/example-nextjs@0.0.94--canary.489.26465713127.0
  npm install @tokenami/config@0.0.94--canary.489.26465713127.0
  npm install @tokenami/css@0.0.94--canary.489.26465713127.0
  npm install @tokenami/ds@0.0.94--canary.489.26465713127.0
  npm install tokenami@0.0.94--canary.489.26465713127.0
  # or 
  yarn add @tokenami/example-design-system@0.0.94--canary.489.26465713127.0
  yarn add @tokenami/example-nextjs@0.0.94--canary.489.26465713127.0
  yarn add @tokenami/config@0.0.94--canary.489.26465713127.0
  yarn add @tokenami/css@0.0.94--canary.489.26465713127.0
  yarn add @tokenami/ds@0.0.94--canary.489.26465713127.0
  yarn add tokenami@0.0.94--canary.489.26465713127.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
