### PR TITLE
fix `CSS.Properties` fallback completions for values

### DIFF
--- a/packages/tokenami/src/ts-plugin/plugin.ts
+++ b/packages/tokenami/src/ts-plugin/plugin.ts
@@ -141,6 +141,14 @@ class TokenamiPlugin {
     } else {
       const result = original();
       const results = completions.valueSearch(result?.entries ?? []);
+
+      // if Tokenami can't provide value completions, fall back to the
+      // default TypeScript completions (e.g. CSS.Properties unions).
+      if (Object.keys(results).length === 0) {
+        this.#completionsForPosition = null;
+        return result;
+      }
+
       this.#completionsForPosition = results;
 
       return {


### PR DESCRIPTION
# Summary

the recent changes to improve TS perf caused a regression here. this fixes it.

## Change Type

<!-- Please indicate the type of change this is -->

- [ ] `documentation`
- [x] `patch`
- [ ] `minor`
- [ ] `major`

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.0.95--canary.491.26826259552.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @tokenami/example-design-system@0.0.95--canary.491.26826259552.0
  npm install @tokenami/example-nextjs@0.0.95--canary.491.26826259552.0
  npm install @tokenami/config@0.0.95--canary.491.26826259552.0
  npm install @tokenami/css@0.0.95--canary.491.26826259552.0
  npm install @tokenami/ds@0.0.95--canary.491.26826259552.0
  npm install tokenami@0.0.95--canary.491.26826259552.0
  # or 
  yarn add @tokenami/example-design-system@0.0.95--canary.491.26826259552.0
  yarn add @tokenami/example-nextjs@0.0.95--canary.491.26826259552.0
  yarn add @tokenami/config@0.0.95--canary.491.26826259552.0
  yarn add @tokenami/css@0.0.95--canary.491.26826259552.0
  yarn add @tokenami/ds@0.0.95--canary.491.26826259552.0
  yarn add tokenami@0.0.95--canary.491.26826259552.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
