### PR TITLE
match config order for value completions

### DIFF
--- a/packages/@tokenami-ds/src/colors.ts
+++ b/packages/@tokenami-ds/src/colors.ts
@@ -131,140 +131,199 @@ import {
 
 const shared = {
   black: 'color(display-p3 0 0 0)',
-  white: 'color(display-p3 1 1 1)',
   ...blackP3A,
+
+  white: 'color(display-p3 1 1 1)',
   ...whiteP3A,
 };
 
 const light = {
   ...grayP3,
-  ...mauveP3,
-  ...slateP3,
-  ...sageP3,
-  ...oliveP3,
-  ...sandP3,
-  ...goldP3,
-  ...bronzeP3,
-  ...brownP3,
-  ...yellowP3,
-  ...amberP3,
-  ...orangeP3,
-  ...tomatoP3,
-  ...redP3,
-  ...rubyP3,
-  ...crimsonP3,
-  ...pinkP3,
-  ...plumP3,
-  ...purpleP3,
-  ...violetP3,
-  ...irisP3,
-  ...indigoP3,
-  ...blueP3,
-  ...cyanP3,
-  ...tealP3,
-  ...jadeP3,
-  ...greenP3,
-  ...grassP3,
-  ...limeP3,
-  ...mintP3,
-  ...skyP3,
-
   ...grayP3A,
+
+  ...mauveP3,
   ...mauveP3A,
+
+  ...slateP3,
   ...slateP3A,
+
+  ...sageP3,
   ...sageP3A,
+
+  ...oliveP3,
   ...oliveP3A,
+
+  ...sandP3,
   ...sandP3A,
+
+  ...goldP3,
   ...goldP3A,
+
+  ...bronzeP3,
   ...bronzeP3A,
+
+  ...brownP3,
   ...brownP3A,
+
+  ...yellowP3,
   ...yellowP3A,
+
+  ...amberP3,
   ...amberP3A,
+
+  ...orangeP3,
   ...orangeP3A,
+
+  ...tomatoP3,
   ...tomatoP3A,
+
+  ...redP3,
   ...redP3A,
+
+  ...rubyP3,
   ...rubyP3A,
+
+  ...crimsonP3,
   ...crimsonP3A,
+
+  ...pinkP3,
   ...pinkP3A,
+
+  ...plumP3,
   ...plumP3A,
+
+  ...purpleP3,
   ...purpleP3A,
+
+  ...violetP3,
   ...violetP3A,
+
+  ...irisP3,
   ...irisP3A,
+
+  ...indigoP3,
   ...indigoP3A,
+
+  ...blueP3,
   ...blueP3A,
+
+  ...cyanP3,
   ...cyanP3A,
+
+  ...tealP3,
   ...tealP3A,
+
+  ...jadeP3,
   ...jadeP3A,
+
+  ...greenP3,
   ...greenP3A,
+
+  ...grassP3,
   ...grassP3A,
+
+  ...limeP3,
   ...limeP3A,
+
+  ...mintP3,
   ...mintP3A,
+
+  ...skyP3,
   ...skyP3A,
 };
 
 const dark = {
   ...grayDarkP3,
-  ...mauveDarkP3,
-  ...slateDarkP3,
-  ...sageDarkP3,
-  ...oliveDarkP3,
-  ...sandDarkP3,
-  ...goldDarkP3,
-  ...bronzeDarkP3,
-  ...brownDarkP3,
-  ...yellowDarkP3,
-  ...amberDarkP3,
-  ...orangeDarkP3,
-  ...tomatoDarkP3,
-  ...redDarkP3,
-  ...rubyDarkP3,
-  ...crimsonDarkP3,
-  ...pinkDarkP3,
-  ...plumDarkP3,
-  ...purpleDarkP3,
-  ...violetDarkP3,
-  ...irisDarkP3,
-  ...indigoDarkP3,
-  ...blueDarkP3,
-  ...cyanDarkP3,
-  ...tealDarkP3,
-  ...jadeDarkP3,
-  ...greenDarkP3,
-  ...grassDarkP3,
-  ...limeDarkP3,
-  ...mintDarkP3,
-  ...skyDarkP3,
-
   ...grayDarkP3A,
+
+  ...mauveDarkP3,
   ...mauveDarkP3A,
+
+  ...slateDarkP3,
   ...slateDarkP3A,
+
+  ...sageDarkP3,
   ...sageDarkP3A,
+
+  ...oliveDarkP3,
   ...oliveDarkP3A,
+
+  ...sandDarkP3,
   ...sandDarkP3A,
+
+  ...goldDarkP3,
   ...goldDarkP3A,
+
+  ...bronzeDarkP3,
   ...bronzeDarkP3A,
+
+  ...brownDarkP3,
   ...brownDarkP3A,
+
+  ...yellowDarkP3,
   ...yellowDarkP3A,
+
+  ...amberDarkP3,
   ...amberDarkP3A,
+
+  ...orangeDarkP3,
   ...orangeDarkP3A,
+
+  ...tomatoDarkP3,
   ...tomatoDarkP3A,
+
+  ...redDarkP3,
   ...redDarkP3A,
+
+  ...rubyDarkP3,
   ...rubyDarkP3A,
+
+  ...crimsonDarkP3,
   ...crimsonDarkP3A,
+
+  ...pinkDarkP3,
   ...pinkDarkP3A,
+
+  ...plumDarkP3,
   ...plumDarkP3A,
+
+  ...purpleDarkP3,
   ...purpleDarkP3A,
+
+  ...violetDarkP3,
   ...violetDarkP3A,
+
+  ...irisDarkP3,
   ...irisDarkP3A,
+
+  ...indigoDarkP3,
   ...indigoDarkP3A,
+
+  ...blueDarkP3,
   ...blueDarkP3A,
+
+  ...cyanDarkP3,
   ...cyanDarkP3A,
+
+  ...tealDarkP3,
   ...tealDarkP3A,
+
+  ...jadeDarkP3,
   ...jadeDarkP3A,
+
+  ...greenDarkP3,
   ...greenDarkP3A,
+
+  ...grassDarkP3,
   ...grassDarkP3A,
+
+  ...limeDarkP3,
   ...limeDarkP3A,
+
+  ...mintDarkP3,
   ...mintDarkP3A,
+
+  ...skyDarkP3,
   ...skyDarkP3A,
 };
 

--- a/packages/@tokenami-node/src/ts-plugin.test.ts
+++ b/packages/@tokenami-node/src/ts-plugin.test.ts
@@ -5,6 +5,7 @@ import { describe, expect, it } from 'vitest';
 import ts from 'typescript/lib/tsserverlibrary.js';
 import type { Config } from '@tokenami/config';
 import { TokenamiDiagnostics } from './ts-plugin/diagnostics';
+import { TokenamiCompletions } from './ts-plugin/completions';
 import { createTSPlugin } from './ts-plugin/plugin';
 
 const testConfig: Config = {
@@ -90,6 +91,34 @@ function createSourceFile(code: string) {
 }
 
 describe('ts plugin', () => {
+  it('sorts token value completions by theme config order', () => {
+    const completions = new TokenamiCompletions(
+      {
+        ...testConfig,
+        theme: {
+          color: {
+            zebra: '#000',
+            apple: '#111',
+            mango: '#222',
+          },
+        },
+      },
+      { logger: { log: () => {}, error: () => {} } }
+    );
+
+    const result = completions.valueSearch([
+      { name: "'var(--color_mango)'", kind: ts.ScriptElementKind.string, sortText: '11' },
+      { name: "'var(--color_zebra)'", kind: ts.ScriptElementKind.string, sortText: '11' },
+      { name: "'var(--color_apple)'", kind: ts.ScriptElementKind.string, sortText: '11' },
+    ]);
+
+    expect(Object.values(result).map((entry) => [entry.name, entry.sortText])).toEqual([
+      ['$mango', '$color000002'],
+      ['$zebra', '$color000000'],
+      ['$apple', '$color000001'],
+    ]);
+  });
+
   it('adds quick info documentation for quoted token values in tokenami objects only', () => {
     const fileName = 'test.ts';
     const code = `

--- a/packages/@tokenami-node/src/ts-plugin/completions.ts
+++ b/packages/@tokenami-node/src/ts-plugin/completions.ts
@@ -24,6 +24,11 @@ type ValueCompletionEntries = {
   };
 };
 
+type ThemeMeta = {
+  colorThemeKeys: Set<string>;
+  tokenValueOrders: Map<TokenamiConfig.TokenValue, number>;
+};
+
 /* -------------------------------------------------------------------------------------------------
  * TokenamiCompletions
  * -----------------------------------------------------------------------------------------------*/
@@ -44,13 +49,13 @@ class TokenamiCompletions {
   // lazily instantiate and cache these
   #_responsiveSelectorSnippets?: SelectorCompletionEntries;
   #_validProperties: string[];
-  #_colorThemeKeys: Set<string>;
+  #_themeMeta: ThemeMeta;
 
   constructor(config: TokenamiConfig.Config, context: TokenamiCompletionsContext) {
     this.#config = config;
     this.#ctx = { ...context, insertFormatter: context.insertFormatter ?? ((name) => name) };
     this.#_validProperties = Array.from(tokenami.getValidProperties(this.#config));
-    this.#_colorThemeKeys = this.#computeColorThemeKeys();
+    this.#_themeMeta = this.#computeThemeMeta();
     this.#selectorEntries = Object.entries(this.#config.selectors || {});
     this.#responsiveEntries = Object.entries(this.#config.responsive || {});
     this.#base = this.#getBaseCompletions();
@@ -81,13 +86,14 @@ class TokenamiCompletions {
 
       const { themeKey, token } = TokenamiConfig.getTokenValueParts(tokenValue.output);
       const name = `$${token}`;
-      const isColor = this.#_colorThemeKeys.has(themeKey);
+      const isColor = this.#_themeMeta.colorThemeKeys.has(themeKey);
+      const order = this.#_themeMeta.tokenValueOrders.get(tokenValue.output);
 
       result[name] = {
         name,
         kind: ts.ScriptElementKind.string,
         kindModifiers: isColor ? 'color' : themeKey,
-        sortText: this.#createSortText(`${index}${entryName}`),
+        sortText: this.#createSortText(`${themeKey + (order ?? index)}`),
         insertText: this.#ctx.insertFormatter(entryName, { type: 'value' }),
         labelDetails: { detail: '', description: entryName },
         details: { themeKey, token },
@@ -136,8 +142,9 @@ class TokenamiCompletions {
     return index > 0 && entryName[index] === '-';
   }
 
-  #createSortText(name: string) {
-    const sortText = name.replace(/[0-9]+/g, (m) => m.padStart(6, '0')).replaceAll('-', '');
+  #createSortText(name: string | number) {
+    const text = String(name);
+    const sortText = text.replace(/[0-9]+/g, (m) => m.padStart(6, '0')).replaceAll('-', '');
     return `$${sortText}`;
   }
 
@@ -233,22 +240,28 @@ class TokenamiCompletions {
     return result;
   }
 
-  #computeColorThemeKeys(): Set<string> {
+  #computeThemeMeta(): ThemeMeta {
     const colorKeys = new Set<string>();
     const theme = tokenami.getThemeFromConfig(this.#config.theme);
-    const themeModes = [theme.root, ...Object.values(theme.modes)];
+    const modes = Object.values(theme.modes);
+    const flatTheme = Object.assign({}, theme.root, ...modes) as TokenamiConfig.Theme;
+    const tokenValueOrders = new Map<TokenamiConfig.TokenValue, number>();
 
-    for (const theme of themeModes) {
-      for (const [themeKey, values] of Object.entries(theme)) {
-        if (colorKeys.has(themeKey)) continue;
-        const firstValue = Object.values(values)[0];
-        if (typeof firstValue === 'string' && isColorValue(firstValue)) {
-          colorKeys.add(themeKey);
-        }
+    for (const [themeKey, tokens] of Object.entries(flatTheme)) {
+      const tokenKeys = Object.keys(tokens);
+      const tokenValues = Object.values(tokens);
+      const firstValue = tokenValues[0];
+
+      if (typeof firstValue === 'string' && isColorValue(firstValue)) {
+        colorKeys.add(themeKey);
+      }
+
+      for (const [index, token] of tokenKeys.entries()) {
+        tokenValueOrders.set(TokenamiConfig.tokenValue(themeKey, token), index);
       }
     }
 
-    return colorKeys;
+    return { colorThemeKeys: colorKeys, tokenValueOrders };
   }
 
   #getSelectorConfigEntries(variants?: string[], arbSelector = '') {


### PR DESCRIPTION
# Summary

makes sure that value completions match the order from theme so that `$10xl` does not appear between `$1xl` and `2xl` (for example).

## Change Type

<!-- Please indicate the type of change this is -->

- [ ] `documentation`
- [ ] `patch`
- [x] `minor`
- [ ] `major`

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.0.96--canary.499.27315605745.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @tokenami/example-design-system@0.0.96--canary.499.27315605745.0
  npm install @tokenami/example-nextjs@0.0.96--canary.499.27315605745.0
  npm install @tokenami/cli@0.0.96--canary.499.27315605745.0
  npm install @tokenami/config@0.0.96--canary.499.27315605745.0
  npm install @tokenami/css@0.0.96--canary.499.27315605745.0
  npm install @tokenami/ds@0.0.96--canary.499.27315605745.0
  npm install @tokenami/node@0.0.96--canary.499.27315605745.0
  npm install tokenami@0.0.96--canary.499.27315605745.0
  # or 
  yarn add @tokenami/example-design-system@0.0.96--canary.499.27315605745.0
  yarn add @tokenami/example-nextjs@0.0.96--canary.499.27315605745.0
  yarn add @tokenami/cli@0.0.96--canary.499.27315605745.0
  yarn add @tokenami/config@0.0.96--canary.499.27315605745.0
  yarn add @tokenami/css@0.0.96--canary.499.27315605745.0
  yarn add @tokenami/ds@0.0.96--canary.499.27315605745.0
  yarn add @tokenami/node@0.0.96--canary.499.27315605745.0
  yarn add tokenami@0.0.96--canary.499.27315605745.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
