### PR TITLE
add default responsive selectors to config stubs

### DIFF
--- a/packages/@tokenami-node/stubs/tokenami.config.cjs
+++ b/packages/@tokenami-node/stubs/tokenami.config.cjs
@@ -3,7 +3,13 @@ const { createConfig } = require('@tokenami/css');
 module.exports = createConfig({
   include: [],
   grid: '0.25rem',
-  responsive: {},
+  responsive: {
+    sm: '@media (width >= 40rem)',
+    md: '@media (width >= 48rem)',
+    lg: '@media (width >= 64rem)',
+    xl: '@media (width >= 80rem)',
+    '2xl': '@media (width >= 96rem)',
+  },
   themeSelector: (mode) => (mode === 'root' ? ':root' : `.theme-${mode}`),
   theme: {
     alpha: {},

--- a/packages/@tokenami-node/stubs/tokenami.config.js
+++ b/packages/@tokenami-node/stubs/tokenami.config.js
@@ -3,7 +3,13 @@ import { createConfig } from '@tokenami/css';
 export default createConfig({
   include: [],
   grid: '0.25rem',
-  responsive: {},
+  responsive: {
+    sm: '@media (width >= 40rem)',
+    md: '@media (width >= 48rem)',
+    lg: '@media (width >= 64rem)',
+    xl: '@media (width >= 80rem)',
+    '2xl': '@media (width >= 96rem)',
+  },
   themeSelector: (mode) => (mode === 'root' ? ':root' : `.theme-${mode}`),
   theme: {
     alpha: {},

--- a/packages/@tokenami-node/stubs/tokenami.config.mjs
+++ b/packages/@tokenami-node/stubs/tokenami.config.mjs
@@ -3,7 +3,13 @@ import { createConfig } from '@tokenami/css';
 export default createConfig({
   include: [],
   grid: '0.25rem',
-  responsive: {},
+  responsive: {
+    sm: '@media (width >= 40rem)',
+    md: '@media (width >= 48rem)',
+    lg: '@media (width >= 64rem)',
+    xl: '@media (width >= 80rem)',
+    '2xl': '@media (width >= 96rem)',
+  },
   themeSelector: (mode) => (mode === 'root' ? ':root' : `.theme-${mode}`),
   theme: {
     alpha: {},

--- a/packages/@tokenami-node/stubs/tokenami.config.ts
+++ b/packages/@tokenami-node/stubs/tokenami.config.ts
@@ -3,7 +3,13 @@ import { createConfig } from '@tokenami/css';
 export default createConfig({
   include: [],
   grid: '0.25rem',
-  responsive: {},
+  responsive: {
+    sm: '@media (width >= 40rem)',
+    md: '@media (width >= 48rem)',
+    lg: '@media (width >= 64rem)',
+    xl: '@media (width >= 80rem)',
+    '2xl': '@media (width >= 96rem)',
+  },
   themeSelector: (mode) => (mode === 'root' ? ':root' : `.theme-${mode}`),
   theme: {
     alpha: {},


### PR DESCRIPTION
## Summary
- Add Tailwind-compatible default responsive selectors to generated Tokenami config stubs
- Enable documented prefixes like `--md_color` to work immediately in new installs

## Test plan
- `pnpm --filter @tokenami/node test`
- `pnpm --filter @tokenami/node typecheck`