### PR TITLE
limit release Discord workflow permissions

### DIFF
--- a/.github/workflows/release-discord.yaml
+++ b/.github/workflows/release-discord.yaml
@@ -5,6 +5,9 @@ on:
     types: [published]
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   notify-discord:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- add explicit `contents: read` permissions to the release Discord workflow
- fix GitHub code scanning alert #1 (`actions/missing-workflow-permissions`)

## Validation
- `pnpm exec prettier --check .github/workflows/release-discord.yaml`
- `git diff --check`

Note: Sweepi was attempted for the changed workflow file, but its scoped run reported unrelated repo-wide findings and no findings for this file.