### PR TITLE
reduce unnecessary action builds

### DIFF
--- a/.github/actions/setup-repo/action.yml
+++ b/.github/actions/setup-repo/action.yml
@@ -5,6 +5,9 @@ inputs:
   pnpm-version:
     description: Version of pnpm to use
     default: 9.x
+  ignore-scripts:
+    description: Skip lifecycle scripts during install
+    default: 'true'
 
 runs:
   using: composite
@@ -36,5 +39,12 @@ runs:
           ${{ runner.os }}-pnpm-store-
 
     - name: 📦 Install dependencies
-      run: pnpm install --frozen-lockfile
+      run: |
+        install_args=(--frozen-lockfile)
+
+        if [[ "${{ inputs.ignore-scripts }}" == 'true' ]]; then
+          install_args+=(--ignore-scripts)
+        fi
+
+        pnpm install "${install_args[@]}"
       shell: bash

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -4,8 +4,16 @@ on:
   push:
     branches:
       - main
+    paths-ignore:
+      - '**/*.md'
+      - '.github/CODEOWNERS'
+      - '.github/PULL_REQUEST_TEMPLATE.md'
   pull_request:
     types: [opened, synchronize, reopened]
+    paths-ignore:
+      - '**/*.md'
+      - '.github/CODEOWNERS'
+      - '.github/PULL_REQUEST_TEMPLATE.md'
   workflow_dispatch:
 
 concurrency:
@@ -13,17 +21,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  build:
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-    steps:
-      - uses: actions/checkout@v3
-      - uses: ./.github/actions/setup-repo
-      - run: pnpm typecheck
-
   test:
-    needs: build
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -33,6 +31,8 @@ jobs:
       - name: Install Playwright browsers
         working-directory: visual-tests/tokenami
         run: npx playwright install --with-deps
+      - run: pnpm build
+      - run: pnpm typecheck
       - run: pnpm test
         env:
           PERCY_TOKEN: ${{ secrets.PERCY_TOKEN }}
@@ -43,7 +43,6 @@ jobs:
   size:
     if: ${{ github.event_name == 'pull_request' }}
     runs-on: ubuntu-latest
-    needs: [build, test]
     env:
       CI_JOB_NUMBER: 1
     permissions:
@@ -52,6 +51,8 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: ./.github/actions/setup-repo
+      - run: pnpm build
+      - run: pnpm typecheck
       - uses: andresz1/size-limit-action@v1
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -4,9 +4,17 @@ on:
   push:
     branches:
       - main
+    paths-ignore:
+      - '**/*.md'
+      - '.github/CODEOWNERS'
+      - '.github/PULL_REQUEST_TEMPLATE.md'
 
   pull_request:
     types: [opened, synchronize, reopened]
+    paths-ignore:
+      - '**/*.md'
+      - '.github/CODEOWNERS'
+      - '.github/PULL_REQUEST_TEMPLATE.md'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -27,6 +35,7 @@ jobs:
           token: ${{ secrets.AUTO_PAT_PROD }}
       - run: git fetch --unshallow --tags
       - uses: ./.github/actions/setup-repo
+      - run: pnpm build
       - run: pnpm release
 
   canary:
@@ -50,4 +59,5 @@ jobs:
           token: ${{ secrets.AUTO_PAT }}
       - run: git fetch --unshallow --tags
       - uses: ./.github/actions/setup-repo
+      - run: pnpm build
       - run: pnpm release


### PR DESCRIPTION
## Summary
- skip install-time postinstall builds by default in the shared CI setup action
- remove the standalone typecheck-only build job to avoid an extra setup/install pass
- run `pnpm build` and `pnpm typecheck` directly in both the test and size jobs before their job-specific checks
- skip heavy build/release workflows for docs-only metadata changes

## Verification
- ruby YAML parse for edited workflow/action files
- pnpm build
- pnpm typecheck

## Notes
- Ran `sweepi . --file .github/actions/setup-repo/action.yml --file .github/workflows/build.yaml --file .github/workflows/release.yaml`, but it reported repo-wide pre-existing lint errors outside these changed YAML files, so there was no actionable lint result for this patch.