### PR TITLE
fix config reloading in plugin

### DIFF
--- a/packages/@tokenami-node/src/utils.ts
+++ b/packages/@tokenami-node/src/utils.ts
@@ -31,7 +31,12 @@ function getConfigAtPath(
   path: string,
   opts: { cache: boolean } = { cache: true }
 ): Tokenami.Config {
+  const ext = pathe.extname(path);
   const config = (() => {
+    if (['.mjs', '.ts', '.cts', '.mts'].includes(ext)) {
+      return lazyJiti({ cache: opts.cache })(path);
+    }
+
     try {
       if (!opts.cache) delete require.cache[require.resolve(path)];
       return require(path);


### PR DESCRIPTION
# Summary

i noticed that when tokenami.config changes are applied in `.ts` configs, the plugin wasn't getting the reloaded config correctly. this fixes that.

## Change Type

<!-- Please indicate the type of change this is -->

- [ ] `documentation`
- [x] `patch`
- [ ] `minor`
- [ ] `major`
