### PR TITLE
Improve Tokenami value autocomplete performance

### DIFF
--- a/.codex/plans/value-autocomplete-performance.md
+++ b/.codex/plans/value-autocomplete-performance.md
@@ -1,0 +1,11 @@
+# Value Autocomplete Performance Plan
+
+## Goal
+
+Improve Tokenami token value autocomplete latency by avoiding TypeScript's original completion provider when the plugin can produce token value completions directly.
+
+## Slices
+
+- S1: Build direct value completion data from Tokenami config and use it in value completion contexts.
+- S2: Preserve fallback behavior for non-Tokenami value contexts and add focused regression coverage.
+- S3: Run quality gates, review the performance-sensitive path, and polish the draft PR.

--- a/packages/@tokenami-node/src/ts-plugin.test.ts
+++ b/packages/@tokenami-node/src/ts-plugin.test.ts
@@ -22,9 +22,15 @@ const testConfig: Config = {
   },
 };
 
-function createPluginTestContext(code = '', fileName = 'test.tsx') {
-  const cwd = createTokenamiProject(testConfig);
+function createPluginTestContext(
+  code = '',
+  fileName = 'test.tsx',
+  overrides: Partial<ts.LanguageService> = {},
+  config = testConfig
+) {
+  const cwd = createTokenamiProject(config);
   const languageService = createLanguageService(fileName, code);
+  Object.assign(languageService, overrides);
   const plugin = createTSPlugin({ typescript: ts }).create({
     languageService,
     config: { configPath: './.tokenami/tokenami.config.cjs' },
@@ -45,6 +51,10 @@ function createPluginTestContext(code = '', fileName = 'test.tsx') {
       const position = code.indexOf('--color', code.indexOf(search)) + 2;
       const quickInfo = plugin.getQuickInfoAtPosition(fileName, position);
       return quickInfo?.documentation?.map((part) => part.text).join('\n');
+    },
+    completions(search: string) {
+      const position = code.indexOf(search) + search.length;
+      return plugin.getCompletionsAtPosition(fileName, position, {});
     },
   };
 }
@@ -117,6 +127,35 @@ describe('ts plugin', () => {
       ['$zebra', '$color000000'],
       ['$apple', '$color000001'],
     ]);
+  });
+
+  it('provides token value completions without calling TypeScript completions', () => {
+    const fileName = 'test.ts';
+    const code = `
+      const value: 'var(--color_accent)' | 'var(--color_brand)' = 'var(--color_accent)';
+    `;
+    const ctx = createPluginTestContext(code, fileName, {
+      getCompletionsAtPosition: () => {
+        throw new Error('Original completions should not be called');
+      },
+    }, {
+      ...testConfig,
+      theme: {
+        color: {
+          accent: '#ff0000',
+          brand: '#0000ff',
+        },
+        size: {
+          sm: '4px',
+        },
+      },
+    });
+
+    const result = ctx.completions("= 'var");
+
+    expect(result?.entries.map((entry) => entry.name)).toContain('$accent');
+    expect(result?.entries.map((entry) => entry.name)).toContain('$brand');
+    expect(result?.entries.map((entry) => entry.name)).not.toContain('$sm');
   });
 
   it('adds quick info documentation for quoted token values in tokenami objects only', () => {

--- a/packages/@tokenami-node/src/ts-plugin.test.ts
+++ b/packages/@tokenami-node/src/ts-plugin.test.ts
@@ -128,19 +128,19 @@ describe('ts plugin', () => {
       { logger: { log: () => {}, error: () => {} } }
     );
 
-    const result = completions.valueSearch(
-      createTokenValueUnionType([
-        'var(--color_mango)',
-        'var(--color_zebra)',
-        'var(--color_apple)',
-      ])
-    );
+    const type = createTokenValueUnionType([
+      'var(--color_mango)',
+      'var(--color_zebra)',
+      'var(--color_apple)',
+    ]);
+    const result = completions.valueSearch(type);
 
     expect(Object.values(result).map((entry) => [entry.name, entry.sortText])).toEqual([
       ['$mango', '$color000002'],
       ['$zebra', '$color000000'],
       ['$apple', '$color000001'],
     ]);
+    expect(completions.valueSearch(type)).toBe(result);
   });
 
   it('provides token value completions without calling TypeScript completions', () => {

--- a/packages/@tokenami-node/src/ts-plugin.test.ts
+++ b/packages/@tokenami-node/src/ts-plugin.test.ts
@@ -100,6 +100,18 @@ function createSourceFile(code: string) {
   return ts.createSourceFile('test.tsx', code, ts.ScriptTarget.Latest, true, ts.ScriptKind.TSX);
 }
 
+function createTokenValueUnionType(values: string[]): ts.Type {
+  return {
+    isStringLiteral: () => false,
+    isUnion: () => true,
+    types: values.map((value) => ({
+      isStringLiteral: () => true,
+      isUnion: () => false,
+      value,
+    })),
+  } as unknown as ts.Type;
+}
+
 describe('ts plugin', () => {
   it('sorts token value completions by theme config order', () => {
     const completions = new TokenamiCompletions(
@@ -116,11 +128,13 @@ describe('ts plugin', () => {
       { logger: { log: () => {}, error: () => {} } }
     );
 
-    const result = completions.valueSearch([
-      { name: "'var(--color_mango)'", kind: ts.ScriptElementKind.string, sortText: '11' },
-      { name: "'var(--color_zebra)'", kind: ts.ScriptElementKind.string, sortText: '11' },
-      { name: "'var(--color_apple)'", kind: ts.ScriptElementKind.string, sortText: '11' },
-    ]);
+    const result = completions.valueSearch(
+      createTokenValueUnionType([
+        'var(--color_mango)',
+        'var(--color_zebra)',
+        'var(--color_apple)',
+      ])
+    );
 
     expect(Object.values(result).map((entry) => [entry.name, entry.sortText])).toEqual([
       ['$mango', '$color000002'],

--- a/packages/@tokenami-node/src/ts-plugin.test.ts
+++ b/packages/@tokenami-node/src/ts-plugin.test.ts
@@ -158,6 +158,29 @@ describe('ts plugin', () => {
     expect(result?.entries.map((entry) => entry.name)).not.toContain('$sm');
   });
 
+  it('falls back to TypeScript completions outside token value contexts', () => {
+    const fileName = 'test.ts';
+    const code = `
+      const value: string = 'hello';
+    `;
+    const ctx = createPluginTestContext(code, fileName, {
+      getCompletionsAtPosition: () => ({
+        entries: [
+          {
+            name: 'toString',
+            kind: ts.ScriptElementKind.memberFunctionElement,
+            sortText: '0',
+          },
+        ],
+        isGlobalCompletion: false,
+        isMemberCompletion: true,
+        isNewIdentifierLocation: false,
+      }),
+    });
+
+    expect(ctx.completions("= 'h")?.entries.map((entry) => entry.name)).toEqual(['toString']);
+  });
+
   it('adds quick info documentation for quoted token values in tokenami objects only', () => {
     const fileName = 'test.ts';
     const code = `

--- a/packages/@tokenami-node/src/ts-plugin/completions.ts
+++ b/packages/@tokenami-node/src/ts-plugin/completions.ts
@@ -78,11 +78,9 @@ class TokenamiCompletions {
     return { ...this.#base, ...variantResults };
   }
 
-  valueSearch(input: ts.Type | ts.CompletionEntry[]): ValueCompletionEntries[string] {
+  valueSearch(input: ts.Type): ValueCompletionEntries[string] {
     const result: ValueCompletionEntries[string] = {};
-    const tokenValues = Array.isArray(input)
-      ? this.#getTokenValuesFromCompletionEntries(input)
-      : this.#getTokenValuesFromType(input);
+    const tokenValues = this.#getTokenValuesFromType(input);
 
     for (const [index, tokenValue] of tokenValues.entries()) {
       const entry = this.#valueEntries[tokenValue] ?? this.#createValueEntry(tokenValue, index);
@@ -90,14 +88,6 @@ class TokenamiCompletions {
     }
 
     return result;
-  }
-
-  #getTokenValuesFromCompletionEntries(entries: ts.CompletionEntry[]): TokenamiConfig.TokenValue[] {
-    return entries.flatMap((entry) => {
-      const entryName = entry.name.replace(/['"]/g, '');
-      const tokenValue = TokenamiConfig.TokenValue.safeParse(entryName);
-      return tokenValue.success ? [tokenValue.output] : [];
-    });
   }
 
   #getTokenValuesFromType(type: ts.Type): TokenamiConfig.TokenValue[] {

--- a/packages/@tokenami-node/src/ts-plugin/completions.ts
+++ b/packages/@tokenami-node/src/ts-plugin/completions.ts
@@ -45,6 +45,7 @@ class TokenamiCompletions {
   #responsiveEntries: [string, string][];
   #base: CompletionEntries;
   #selectorSnippets: SelectorCompletionEntries;
+  #valueEntries: ValueCompletionEntries[string];
 
   // lazily instantiate and cache these
   #_responsiveSelectorSnippets?: SelectorCompletionEntries;
@@ -60,6 +61,7 @@ class TokenamiCompletions {
     this.#responsiveEntries = Object.entries(this.#config.responsive || {});
     this.#base = this.#getBaseCompletions();
     this.#selectorSnippets = this.#getSelectorSnippetCompletions();
+    this.#valueEntries = this.#getValueCompletions();
   }
 
   get #responsiveSelectorSnippets() {
@@ -76,31 +78,39 @@ class TokenamiCompletions {
     return { ...this.#base, ...variantResults };
   }
 
-  valueSearch(original: (ts.CompletionEntry | TokenamiConfig.TokenValue)[]): ValueCompletionEntries[string] {
+  valueSearch(input: ts.Type | ts.CompletionEntry[]): ValueCompletionEntries[string] {
     const result: ValueCompletionEntries[string] = {};
+    const tokenValues = Array.isArray(input)
+      ? this.#getTokenValuesFromCompletionEntries(input)
+      : this.#getTokenValuesFromType(input);
 
-    for (const [index, entry] of original.entries()) {
-      const entryName = typeof entry === 'string' ? entry : entry.name.replace(/['"]/g, '');
-      const tokenValue = TokenamiConfig.TokenValue.safeParse(entryName);
-      if (!tokenValue.success) continue;
-
-      const { themeKey, token } = TokenamiConfig.getTokenValueParts(tokenValue.output);
-      const name = `$${token}`;
-      const isColor = this.#_themeMeta.colorThemeKeys.has(themeKey);
-      const order = this.#_themeMeta.tokenValueOrders.get(tokenValue.output);
-
-      result[name] = {
-        name,
-        kind: ts.ScriptElementKind.string,
-        kindModifiers: isColor ? 'color' : themeKey,
-        sortText: this.#createSortText(`${themeKey + (order ?? index)}`),
-        insertText: this.#ctx.insertFormatter(entryName, { type: 'value' }),
-        labelDetails: { detail: '', description: entryName },
-        details: { themeKey, token },
-      };
+    for (const [index, tokenValue] of tokenValues.entries()) {
+      const entry = this.#valueEntries[tokenValue] ?? this.#createValueEntry(tokenValue, index);
+      result[entry.name] = entry;
     }
 
     return result;
+  }
+
+  #getTokenValuesFromCompletionEntries(entries: ts.CompletionEntry[]): TokenamiConfig.TokenValue[] {
+    return entries.flatMap((entry) => {
+      const entryName = entry.name.replace(/['"]/g, '');
+      const tokenValue = TokenamiConfig.TokenValue.safeParse(entryName);
+      return tokenValue.success ? [tokenValue.output] : [];
+    });
+  }
+
+  #getTokenValuesFromType(type: ts.Type): TokenamiConfig.TokenValue[] {
+    if (type.isStringLiteral()) {
+      const tokenValue = TokenamiConfig.TokenValue.safeParse(type.value);
+      return tokenValue.success ? [tokenValue.output] : [];
+    }
+
+    if (type.isUnion()) {
+      return type.types.flatMap((t) => this.#getTokenValuesFromType(t));
+    }
+
+    return [];
   }
 
   variantSearch(input: string): SelectorCompletionEntries {
@@ -155,6 +165,17 @@ class TokenamiCompletions {
       const entry = this.#createPropertyEntry(name, this.#createSortText(`$${name}`));
       result[entry.name] = entry;
     }
+    return result;
+  }
+
+  #getValueCompletions(): ValueCompletionEntries[string] {
+    const result: ValueCompletionEntries[string] = {};
+
+    for (const [tokenValue, index] of this.#_themeMeta.tokenValueOrders) {
+      const entry = this.#createValueEntry(tokenValue, index);
+      result[tokenValue] = entry;
+    }
+
     return result;
   }
 
@@ -333,6 +354,23 @@ class TokenamiCompletions {
       sortText,
       insertText,
       ...(isSnippet && { isSnippet }),
+    };
+  }
+
+  #createValueEntry(tokenValue: TokenamiConfig.TokenValue, index: number): ValueCompletionEntry {
+    const { themeKey, token } = TokenamiConfig.getTokenValueParts(tokenValue);
+    const name = `$${token}`;
+    const isColor = this.#_themeMeta.colorThemeKeys.has(themeKey);
+    const order = this.#_themeMeta.tokenValueOrders.get(tokenValue);
+
+    return {
+      name,
+      kind: ts.ScriptElementKind.string,
+      kindModifiers: isColor ? 'color' : themeKey,
+      sortText: this.#createSortText(`${themeKey + (order ?? index)}`),
+      insertText: this.#ctx.insertFormatter(tokenValue, { type: 'value' }),
+      labelDetails: { detail: '', description: tokenValue },
+      details: { themeKey, token },
     };
   }
 }

--- a/packages/@tokenami-node/src/ts-plugin/completions.ts
+++ b/packages/@tokenami-node/src/ts-plugin/completions.ts
@@ -80,7 +80,7 @@ class TokenamiCompletions {
 
   valueSearch(input: ts.Type): ValueCompletionEntries[string] {
     const result: ValueCompletionEntries[string] = {};
-    const tokenValues = this.#getTokenValuesFromType(input);
+    const tokenValues = this.getTokenValuesFromType(input);
 
     for (const [index, tokenValue] of tokenValues.entries()) {
       const entry = this.#valueEntries[tokenValue] ?? this.#createValueEntry(tokenValue, index);
@@ -90,14 +90,14 @@ class TokenamiCompletions {
     return result;
   }
 
-  #getTokenValuesFromType(type: ts.Type): TokenamiConfig.TokenValue[] {
+  getTokenValuesFromType(type: ts.Type): TokenamiConfig.TokenValue[] {
     if (type.isStringLiteral()) {
       const tokenValue = TokenamiConfig.TokenValue.safeParse(type.value);
       return tokenValue.success ? [tokenValue.output] : [];
     }
 
     if (type.isUnion()) {
-      return type.types.flatMap((t) => this.#getTokenValuesFromType(t));
+      return type.types.flatMap((t) => this.getTokenValuesFromType(t));
     }
 
     return [];

--- a/packages/@tokenami-node/src/ts-plugin/completions.ts
+++ b/packages/@tokenami-node/src/ts-plugin/completions.ts
@@ -76,11 +76,11 @@ class TokenamiCompletions {
     return { ...this.#base, ...variantResults };
   }
 
-  valueSearch(original: ts.CompletionEntry[]): ValueCompletionEntries[string] {
+  valueSearch(original: (ts.CompletionEntry | TokenamiConfig.TokenValue)[]): ValueCompletionEntries[string] {
     const result: ValueCompletionEntries[string] = {};
 
     for (const [index, entry] of original.entries()) {
-      const entryName = entry.name.replace(/['"]/g, '');
+      const entryName = typeof entry === 'string' ? entry : entry.name.replace(/['"]/g, '');
       const tokenValue = TokenamiConfig.TokenValue.safeParse(entryName);
       if (!tokenValue.success) continue;
 
@@ -249,15 +249,16 @@ class TokenamiCompletions {
 
     for (const [themeKey, tokens] of Object.entries(flatTheme)) {
       const tokenKeys = Object.keys(tokens);
-      const tokenValues = Object.values(tokens);
-      const firstValue = tokenValues[0];
+      const themeValues = Object.values(tokens);
+      const firstValue = themeValues[0];
 
       if (typeof firstValue === 'string' && isColorValue(firstValue)) {
         colorKeys.add(themeKey);
       }
 
       for (const [index, token] of tokenKeys.entries()) {
-        tokenValueOrders.set(TokenamiConfig.tokenValue(themeKey, token), index);
+        const tokenValue = TokenamiConfig.tokenValue(themeKey, token);
+        tokenValueOrders.set(tokenValue, index);
       }
     }
 

--- a/packages/@tokenami-node/src/ts-plugin/completions.ts
+++ b/packages/@tokenami-node/src/ts-plugin/completions.ts
@@ -46,6 +46,7 @@ class TokenamiCompletions {
   #base: CompletionEntries;
   #selectorSnippets: SelectorCompletionEntries;
   #valueEntries: ValueCompletionEntries[string];
+  #valueSearches = new WeakMap<ts.Type, ValueCompletionEntries[string]>();
 
   // lazily instantiate and cache these
   #_responsiveSelectorSnippets?: SelectorCompletionEntries;
@@ -79,6 +80,9 @@ class TokenamiCompletions {
   }
 
   valueSearch(input: ts.Type): ValueCompletionEntries[string] {
+    const cached = this.#valueSearches.get(input);
+    if (cached) return cached;
+
     const result: ValueCompletionEntries[string] = {};
     const tokenValues = this.getTokenValuesFromType(input);
 
@@ -87,6 +91,7 @@ class TokenamiCompletions {
       result[entry.name] = entry;
     }
 
+    this.#valueSearches.set(input, result);
     return result;
   }
 

--- a/packages/@tokenami-node/src/ts-plugin/plugin.ts
+++ b/packages/@tokenami-node/src/ts-plugin/plugin.ts
@@ -139,12 +139,12 @@ class TokenamiPlugin {
         },
       };
     } else {
-      const result = original();
-      const results = completions.valueSearch(result?.entries ?? []);
+      const results = completions.valueSearch(input.tokenValues);
 
-      // if Tokenami can't provide value completions, fall back to the
-      // default TypeScript completions (e.g. CSS.Properties unions).
+      // If Tokenami can't provide value completions, fall back to the default
+      // TypeScript completions (e.g. CSS.Properties unions).
       if (Object.keys(results).length === 0) {
+        const result = original();
         this.#completionsForPosition = null;
         return result;
       }
@@ -284,14 +284,19 @@ class TokenamiPlugin {
     node: ts.Node,
     fileName: string,
     position: number
-  ): { value: string; isTokenamiProperty: boolean } | null {
+  ): {
+    value: string;
+    isTokenamiProperty: boolean;
+    tokenValues: TokenamiConfig.TokenValue[];
+  } | null {
     const objLit = ts.findAncestor(node, ts.isObjectLiteralExpression);
 
     // No object literal - check for standalone value position
     if (!objLit) {
       if (!ts.isStringLiteral(node)) return null;
-      if (!this.#isTokenValueContext(node)) return null;
-      return { isTokenamiProperty: false, value: node.getText() };
+      const tokenValues = this.#getTokenValuesForContext(node);
+      if (tokenValues.length === 0) return null;
+      return { isTokenamiProperty: false, value: node.getText(), tokenValues };
     }
 
     // Find the property at cursor position
@@ -302,7 +307,9 @@ class TokenamiPlugin {
 
     // Not a property assignment (e.g. shorthand) - only valid in tokenami objects
     if (!ts.isPropertyAssignment(prop)) {
-      return isTokenamiObj ? { isTokenamiProperty: true, value: prop.getText() } : null;
+      return isTokenamiObj
+        ? { isTokenamiProperty: true, value: prop.getText(), tokenValues: [] }
+        : null;
     }
 
     // Determine if cursor is on property name or value
@@ -311,32 +318,35 @@ class TokenamiPlugin {
 
     if (isTokenamiObj) {
       const value = isOnProperty ? prop.name.getText() : prop.initializer.getText();
-      return { isTokenamiProperty: isOnProperty, value };
+      const tokenValues = isOnProperty ? [] : this.#getTokenValuesForContext(prop.initializer);
+      return { isTokenamiProperty: isOnProperty, value, tokenValues };
     }
 
     // Not a tokenami object - only handle value position with TokenValue context
     if (isOnProperty) return null;
-    if (!this.#isTokenValueContext(prop.initializer)) return null;
-    return { isTokenamiProperty: false, value: prop.initializer.getText() };
+    const tokenValues = this.#getTokenValuesForContext(prop.initializer);
+    if (tokenValues.length === 0) return null;
+    return { isTokenamiProperty: false, value: prop.initializer.getText(), tokenValues };
   }
 
-  #isTokenValueContext(node: ts.Expression): boolean {
+  #getTokenValuesForContext(node: ts.Expression): TokenamiConfig.TokenValue[] {
     const checker = this.#ctx.info.languageService.getProgram()?.getTypeChecker();
     const contextualType = checker?.getContextualType(node);
-    if (!contextualType) return false;
-    return this.#hasTokenValueType(contextualType);
+    if (!contextualType) return [];
+    return this.#getTokenValuesFromType(contextualType);
   }
 
-  #hasTokenValueType(type: ts.Type): boolean {
+  #getTokenValuesFromType(type: ts.Type): TokenamiConfig.TokenValue[] {
     if (type.isStringLiteral()) {
-      return TokenamiConfig.TokenValue.safeParse(type.value).success;
+      const tokenValue = TokenamiConfig.TokenValue.safeParse(type.value);
+      return tokenValue.success ? [tokenValue.output] : [];
     }
 
     if (type.isUnion()) {
-      return type.types.some((t) => this.#hasTokenValueType(t));
+      return type.types.flatMap((t) => this.#getTokenValuesFromType(t));
     }
 
-    return false;
+    return [];
   }
 
   #isTokenamiObjectCache = TokenamiConfig.createLRUCache();

--- a/packages/@tokenami-node/src/ts-plugin/plugin.ts
+++ b/packages/@tokenami-node/src/ts-plugin/plugin.ts
@@ -139,7 +139,8 @@ class TokenamiPlugin {
         },
       };
     } else {
-      const results = completions.valueSearch(input.tokenValues);
+      if (!input.contextualType) return original();
+      const results = completions.valueSearch(input.contextualType);
 
       // If Tokenami can't provide value completions, fall back to the default
       // TypeScript completions (e.g. CSS.Properties unions).
@@ -287,16 +288,16 @@ class TokenamiPlugin {
   ): {
     value: string;
     isTokenamiProperty: boolean;
-    tokenValues: TokenamiConfig.TokenValue[];
+    contextualType?: ts.Type;
   } | null {
     const objLit = ts.findAncestor(node, ts.isObjectLiteralExpression);
 
     // No object literal - check for standalone value position
     if (!objLit) {
       if (!ts.isStringLiteral(node)) return null;
-      const tokenValues = this.#getTokenValuesForContext(node);
-      if (tokenValues.length === 0) return null;
-      return { isTokenamiProperty: false, value: node.getText(), tokenValues };
+      const contextualType = this.#getTokenValueContext(node);
+      if (!contextualType) return null;
+      return { isTokenamiProperty: false, value: node.getText(), contextualType };
     }
 
     // Find the property at cursor position
@@ -307,9 +308,7 @@ class TokenamiPlugin {
 
     // Not a property assignment (e.g. shorthand) - only valid in tokenami objects
     if (!ts.isPropertyAssignment(prop)) {
-      return isTokenamiObj
-        ? { isTokenamiProperty: true, value: prop.getText(), tokenValues: [] }
-        : null;
+      return isTokenamiObj ? { isTokenamiProperty: true, value: prop.getText() } : null;
     }
 
     // Determine if cursor is on property name or value
@@ -318,35 +317,35 @@ class TokenamiPlugin {
 
     if (isTokenamiObj) {
       const value = isOnProperty ? prop.name.getText() : prop.initializer.getText();
-      const tokenValues = isOnProperty ? [] : this.#getTokenValuesForContext(prop.initializer);
-      return { isTokenamiProperty: isOnProperty, value, tokenValues };
+      const contextualType = isOnProperty ? undefined : this.#getTokenValueContext(prop.initializer);
+      if (!isOnProperty && !contextualType) return null;
+      return { isTokenamiProperty: isOnProperty, value, contextualType };
     }
 
     // Not a tokenami object - only handle value position with TokenValue context
     if (isOnProperty) return null;
-    const tokenValues = this.#getTokenValuesForContext(prop.initializer);
-    if (tokenValues.length === 0) return null;
-    return { isTokenamiProperty: false, value: prop.initializer.getText(), tokenValues };
+    const contextualType = this.#getTokenValueContext(prop.initializer);
+    if (!contextualType) return null;
+    return { isTokenamiProperty: false, value: prop.initializer.getText(), contextualType };
   }
 
-  #getTokenValuesForContext(node: ts.Expression): TokenamiConfig.TokenValue[] {
+  #getTokenValueContext(node: ts.Expression): ts.Type | undefined {
     const checker = this.#ctx.info.languageService.getProgram()?.getTypeChecker();
     const contextualType = checker?.getContextualType(node);
-    if (!contextualType) return [];
-    return this.#getTokenValuesFromType(contextualType);
+    if (!contextualType) return;
+    return this.#hasTokenValueType(contextualType) ? contextualType : undefined;
   }
 
-  #getTokenValuesFromType(type: ts.Type): TokenamiConfig.TokenValue[] {
+  #hasTokenValueType(type: ts.Type): boolean {
     if (type.isStringLiteral()) {
-      const tokenValue = TokenamiConfig.TokenValue.safeParse(type.value);
-      return tokenValue.success ? [tokenValue.output] : [];
+      return TokenamiConfig.TokenValue.safeParse(type.value).success;
     }
 
     if (type.isUnion()) {
-      return type.types.flatMap((t) => this.#getTokenValuesFromType(t));
+      return type.types.some((t) => this.#hasTokenValueType(t));
     }
 
-    return [];
+    return false;
   }
 
   #isTokenamiObjectCache = TokenamiConfig.createLRUCache();

--- a/packages/@tokenami-node/src/ts-plugin/plugin.ts
+++ b/packages/@tokenami-node/src/ts-plugin/plugin.ts
@@ -139,8 +139,10 @@ class TokenamiPlugin {
         },
       };
     } else {
-      if (!input.contextualType) return original();
-      const results = completions.valueSearch(input.contextualType);
+      const contextualType = this.#getTokenValueContext(node);
+      if (!contextualType) return original();
+
+      const results = completions.valueSearch(contextualType);
 
       // If Tokenami can't provide value completions, fall back to the default
       // TypeScript completions (e.g. CSS.Properties unions).
@@ -288,16 +290,13 @@ class TokenamiPlugin {
   ): {
     value: string;
     isTokenamiProperty: boolean;
-    contextualType?: ts.Type;
   } | null {
     const objLit = ts.findAncestor(node, ts.isObjectLiteralExpression);
 
     // No object literal - check for standalone value position
     if (!objLit) {
       if (!ts.isStringLiteral(node)) return null;
-      const contextualType = this.#getTokenValueContext(node);
-      if (!contextualType) return null;
-      return { isTokenamiProperty: false, value: node.getText(), contextualType };
+      return { isTokenamiProperty: false, value: node.getText() };
     }
 
     // Find the property at cursor position
@@ -317,19 +316,16 @@ class TokenamiPlugin {
 
     if (isTokenamiObj) {
       const value = isOnProperty ? prop.name.getText() : prop.initializer.getText();
-      const contextualType = isOnProperty ? undefined : this.#getTokenValueContext(prop.initializer);
-      if (!isOnProperty && !contextualType) return null;
-      return { isTokenamiProperty: isOnProperty, value, contextualType };
+      return { isTokenamiProperty: isOnProperty, value };
     }
 
     // Not a tokenami object - only handle value position with TokenValue context
     if (isOnProperty) return null;
-    const contextualType = this.#getTokenValueContext(prop.initializer);
-    if (!contextualType) return null;
-    return { isTokenamiProperty: false, value: prop.initializer.getText(), contextualType };
+    return { isTokenamiProperty: false, value: prop.initializer.getText() };
   }
 
-  #getTokenValueContext(node: ts.Expression): ts.Type | undefined {
+  #getTokenValueContext(node: ts.Node): ts.Type | undefined {
+    if (!ts.isExpression(node)) return;
     const checker = this.#ctx.info.languageService.getProgram()?.getTypeChecker();
     const contextualType = checker?.getContextualType(node);
     if (!contextualType) return;

--- a/packages/@tokenami-node/src/ts-plugin/plugin.ts
+++ b/packages/@tokenami-node/src/ts-plugin/plugin.ts
@@ -343,8 +343,7 @@ class TokenamiPlugin {
     const cacheKey = `${fileName}:${objLit.pos}:${textBeforeBrace}`;
     if (this.#isTokenamiObjectCache.get(cacheKey)) return true;
 
-    const checker = this.#ctx.info.languageService.getProgram()?.getTypeChecker();
-    const contextual = checker?.getContextualType(objLit);
+    const contextual = this.#getContextualType(objLit);
     if (!contextual) return false;
 
     const isTokenami = this.#hasTokenamiType(contextual);

--- a/packages/@tokenami-node/src/ts-plugin/plugin.ts
+++ b/packages/@tokenami-node/src/ts-plugin/plugin.ts
@@ -139,8 +139,9 @@ class TokenamiPlugin {
         },
       };
     } else {
-      const contextualType = this.#getTokenValueContext(node);
+      const contextualType = this.#getContextualType(node);
       if (!contextualType) return original();
+      if (completions.getTokenValuesFromType(contextualType).length === 0) return original();
 
       const results = completions.valueSearch(contextualType);
 
@@ -324,24 +325,10 @@ class TokenamiPlugin {
     return { isTokenamiProperty: false, value: prop.initializer.getText() };
   }
 
-  #getTokenValueContext(node: ts.Node): ts.Type | undefined {
+  #getContextualType(node: ts.Node): ts.Type | undefined {
     if (!ts.isExpression(node)) return;
     const checker = this.#ctx.info.languageService.getProgram()?.getTypeChecker();
-    const contextualType = checker?.getContextualType(node);
-    if (!contextualType) return;
-    return this.#hasTokenValueType(contextualType) ? contextualType : undefined;
-  }
-
-  #hasTokenValueType(type: ts.Type): boolean {
-    if (type.isStringLiteral()) {
-      return TokenamiConfig.TokenValue.safeParse(type.value).success;
-    }
-
-    if (type.isUnion()) {
-      return type.types.some((t) => this.#hasTokenValueType(t));
-    }
-
-    return false;
+    return checker?.getContextualType(node);
   }
 
   #isTokenamiObjectCache = TokenamiConfig.createLRUCache();


### PR DESCRIPTION
## Summary
- avoid TypeScript's slow original completion provider for Tokenami token value contexts when allowed token literals can be derived directly
- preserve contextual filtering so narrow value types only receive assignable token values
- cache complete valueSearch results by contextual TypeScript type
- cache Tokenami value completion entries in completions.ts, keeping plugin parsing focused on text/property-vs-value detection
- reuse completions.ts token-value type extraction from plugin.ts instead of duplicating recursive type traversal
- centralize contextual type lookup through #getContextualType in plugin.ts
- keep fallback behavior for non-token or ambiguous value contexts
- remove the legacy CompletionEntry[] valueSearch path now that production calls pass contextual types

## Slices
- S0: plan committed
- S1: direct contextual token value completions implemented
- S2: fallback boundary covered
- S3: package-level verification passed
- S4: value completion caching moved into TokenamiCompletions
- S5: legacy valueSearch CompletionEntry[] input removed
- S6: parser simplified so contextual type lookup happens in the value branch
- S7: plugin reuses TokenamiCompletions token-value type extraction
- S8: tokenami object detection reuses #getContextualType
- S9: valueSearch results cached by contextual type

## Verification
- pnpm --filter @tokenami/node test
- pnpm --filter @tokenami/node test src/ts-plugin.test.ts
- pnpm --filter @tokenami/node typecheck
- git diff --check