### PR TITLE
fix inherit overrides in compose blocks

### DIFF
--- a/examples/nextjs/src/components/selectable-list.tsx
+++ b/examples/nextjs/src/components/selectable-list.tsx
@@ -71,7 +71,6 @@ const selectableListItem = css.compose({
 });
 
 const selectableListTrigger = css.compose({
-  '--background-color': 'inherit',
   '--transition': 'var(--morph_colors)',
   '--position': 'absolute',
   '--inset': 0,

--- a/packages/@tokenami-node/src/core.ts
+++ b/packages/@tokenami-node/src/core.ts
@@ -4,20 +4,21 @@ import * as fs from 'fs';
 import * as csstree from 'css-tree';
 import ts from 'typescript/lib/tsserverlibrary.js';
 import * as pathe from 'pathe';
-import { type TokenamiProperties } from './declarations';
 import * as sheet from './sheet';
 import * as utils from './utils';
 
 type Writeable<T> = { -readonly [P in keyof T]: T[P] };
+type ComposeBlock = Record<string, string | number>;
+type ComposeBlocks = Record<`.${string}`, ComposeBlock>;
 
 interface UsedTokens {
   properties: Tokenami.TokenProperty[];
   values: Tokenami.TokenValue[];
-  composeBlocks: Record<`.${string}`, TokenamiProperties>;
+  composeBlocks: ComposeBlocks;
 }
 
 interface FileTokens {
-  prevComposeBlocks: Record<`.${string}`, TokenamiProperties>[];
+  prevComposeBlocks: ComposeBlocks[];
   current: UsedTokens;
 }
 
@@ -66,7 +67,7 @@ class TokenStore {
   getTokens(): UsedTokens {
     let properties: Tokenami.TokenProperty[] = [];
     let values: Tokenami.TokenValue[] = [];
-    let composeBlocks: Record<`.${string}`, TokenamiProperties> = {};
+    let composeBlocks: ComposeBlocks = {};
 
     for (const fileTokens of this.#tokensByFile.values()) {
       properties = [...properties, ...fileTokens.current.properties];
@@ -114,9 +115,9 @@ async function findUsedTokens(cwd: string, config: Tokenami.Config): Promise<Use
   return store.getTokens();
 }
 
-function findComposeBlocks(content: string): Record<`.${string}`, TokenamiProperties> {
+function findComposeBlocks(content: string): ComposeBlocks {
   const sourceFile = ts.createSourceFile('tokenami.tsx', content, ts.ScriptTarget.Latest, true);
-  let result: Record<`.${string}`, TokenamiProperties> = {};
+  let result: ComposeBlocks = {};
 
   function visit(node: ts.Node) {
     if (
@@ -150,8 +151,8 @@ function isComposeCall(node: ts.Node): node is ts.CallExpression {
   );
 }
 
-function getComposeBlockStyles(node: ts.ObjectLiteralExpression): TokenamiProperties | undefined {
-  let styles: TokenamiProperties | undefined;
+function getComposeBlockStyles(node: ts.ObjectLiteralExpression): ComposeBlock | undefined {
+  let styles: ComposeBlock | undefined;
 
   for (const property of node.properties) {
     if (!ts.isPropertyAssignment(property)) continue;
@@ -161,7 +162,7 @@ function getComposeBlockStyles(node: ts.ObjectLiteralExpression): TokenamiProper
     if (value === undefined) continue;
 
     styles ??= {};
-    styles[property.name.text as any] = value;
+    styles[property.name.text] = value;
   }
 
   return styles;
@@ -204,7 +205,7 @@ function matchTokens(content: string, theme: Tokenami.Config['theme']) {
 
 function findSheetComposeBlocks(fileContents: string) {
   const ast = csstree.parse(fileContents);
-  let stylesObject: Record<`.${string}`, TokenamiProperties> | undefined;
+  let stylesObject: ComposeBlocks | undefined;
 
   csstree.walk(ast, {
     visit: 'Atrule',
@@ -219,7 +220,7 @@ function findSheetComposeBlocks(fileContents: string) {
           enter(ruleNode) {
             if (!ruleNode.prelude || !ruleNode.block) return;
             const selector = csstree.generate(ruleNode.prelude).trim();
-            let styles: TokenamiProperties = {};
+            let styles: ComposeBlock = {};
 
             csstree.walk(ruleNode.block, {
               visit: 'Declaration',
@@ -243,4 +244,4 @@ function findSheetComposeBlocks(fileContents: string) {
 }
 
 export { TokenStore, findUsedTokens };
-export type { UsedTokens };
+export type { UsedTokens, ComposeBlocks };

--- a/packages/@tokenami-node/src/sheet.test.ts
+++ b/packages/@tokenami-node/src/sheet.test.ts
@@ -8,6 +8,15 @@ const testConfig: Config = {
   theme: { color: { accent: '#ff0000' } },
   properties: {
     color: ['color'],
+    'background-color': ['color'],
+    'block-size': ['grid'],
+  },
+  aliases: {
+    height: ['block-size'],
+  },
+  grid: '0.25rem',
+  selectors: {
+    hover: '&:hover',
   },
 };
 
@@ -23,5 +32,63 @@ describe('sheet', () => {
     });
 
     expect(sheet).not.toContain('--_grid: undefined');
+  });
+
+  it('emits composed inherit values as native properties with token variable fallbacks', () => {
+    const sheet = createSheet({
+      config: testConfig,
+      tokens: {
+        properties: ['--hover_background-color', '--background-color'],
+        values: ['var(--color_accent)'],
+        composeBlocks: {
+          '.tk-parent': {
+            '--hover_background-color': 'var(--color_accent)',
+          },
+          '.tk-child': {
+            '--background-color': 'inherit',
+          },
+        },
+      },
+    });
+
+    expect(sheet).toMatch(
+      /@layer tks\d+\s*{\s*\.tk-parent\s*,\s*\[style\]\s*{\s*background-color: var\(--_[^;}]+/
+    );
+    expect(sheet).toMatch(
+      /@layer tkc\s*{\s*\.tk-child\s*{\s*background-color: var\(--background-color, inherit\)/
+    );
+    expect(sheet).not.toMatch(/@layer tkc\s*{\s*\.tk-child\s*{\s*--background-color: inherit/);
+  });
+
+  it('preserves selector overrides when a child inherits a grid-backed property', () => {
+    const sheet = createSheet({
+      config: testConfig,
+      tokens: {
+        properties: ['--height', '--hover_height'],
+        values: [],
+        composeBlocks: {
+          '.tk-parent': {
+            '--height': 10,
+            '--hover_height': 20,
+          },
+          '.tk-child': {
+            '--height': 'inherit',
+          },
+        },
+      },
+    });
+
+    expect(sheet).toMatch(
+      /@layer tksl\d+\s*{\s*\.tk-parent\s*,\s*\[style\]\s*{\s*block-size: var\(--_[^;}]+/
+    );
+    expect(sheet).toMatch(/@layer tkc\s*{\s*\.tk-parent\s*{\s*--block-size: 10/);
+    expect(sheet).toMatch(/@layer tkc\s*{\s*\.tk-parent\s*{\s*--hover_block-size: 20/);
+    expect(sheet).toMatch(
+      /@layer tkc\s*{\s*\.tk-child\s*{\s*block-size: var\(--_[^,]+,\s*var\(--block-size, inherit\)\)/
+    );
+    expect(sheet).toMatch(
+      /@layer tkc\s*{\s*\.tk-child\s*{\s*--_[^:]+: var\(--block-size__calc\) calc\(var\(--block-size\) \* var\(--_grid\)\)/
+    );
+    expect(sheet).not.toMatch(/@layer tkc\s*{\s*\.tk-child\s*{\s*--block-size: inherit/);
   });
 });

--- a/packages/@tokenami-node/src/sheet.ts
+++ b/packages/@tokenami-node/src/sheet.ts
@@ -1,6 +1,7 @@
 import * as Tokenami from '@tokenami/config';
 import { stringify } from '@stitches/stringify';
 import { type TokenamiProperties } from './declarations';
+import { type ComposeBlocks } from './core';
 import * as utils from './utils';
 import * as Supports from './supports';
 
@@ -28,7 +29,7 @@ type CreateSheetParams = {
   tokens: {
     properties: Tokenami.TokenProperty[];
     values: Tokenami.TokenValue[];
-    composeBlocks: Record<`.${string}`, TokenamiProperties>;
+    composeBlocks: ComposeBlocks;
   };
 };
 
@@ -142,7 +143,7 @@ class Sheet {
     this.themeTokenSelectors.push(...baseSelectors.map(removePseudoElementSelector));
   }
 
-  addDeclaration(layer: string, selector: string, property: string, value: string) {
+  addDeclaration(layer: string, selector: string, property: string, value: string | number) {
     const declaration = `${property}: ${value}`;
     const template = `@layer ${layer} { ${SELECTOR_TAG} { ${declaration} } }`;
     this.layers[template] ??= new Set<string>();
@@ -376,25 +377,40 @@ class Sheet {
  * parseComposeBlocks
  * -----------------------------------------------------------------------------------------------*/
 
-function parseComposeBlocks(
-  composeBlocks: Record<`.${string}`, TokenamiProperties>,
-  config: Tokenami.Config
-) {
-  let parsedComposeBlocks: Record<`.${string}`, TokenamiProperties> = {};
+function parseComposeBlocks(composeBlocks: ComposeBlocks, config: Tokenami.Config) {
+  let parsedComposeBlocks: ComposeBlocks = {};
   const entries = Object.entries(composeBlocks);
 
   for (const [selector, tokenamiProperties] of entries) {
     const entries = Object.entries(tokenamiProperties);
     const aliasProperties = Tokenami.iterateAliasProperties(entries, config);
-    let styles: TokenamiProperties = {};
+    let styles: Record<string, string> = {};
 
     for (let [key, value, propertyConfig] of aliasProperties) {
       const tokenProperty = key as Tokenami.TokenProperty;
+      const parts = Tokenami.getTokenPropertySplit(tokenProperty);
 
       for (const cssProperty of propertyConfig.cssProperties) {
         const longProperty = Tokenami.createLonghandProperty(tokenProperty, cssProperty);
         const parsedProperty = Tokenami.parseProperty(longProperty);
         const calcToggle = Tokenami.calcProperty(parsedProperty);
+        const shouldUseBaseProperty = parts.variants.length === 0 && isCSSWideKeyword(value);
+
+        if (shouldUseBaseProperty) {
+          const isGrid = isGridProperty(cssProperty, config);
+          const propertyValue = isGrid
+            ? createGridPropertyValue(parsedProperty, value)
+            : createBasePropertyValue(parsedProperty, value);
+
+          styles[cssProperty] = propertyValue;
+
+          if (isGrid) {
+            const hashGridProperty = hashVariantProperty('grid', parsedProperty);
+            styles[hashGridProperty] = createGridToggleValue(parsedProperty);
+          }
+
+          continue;
+        }
 
         styles[parsedProperty as keyof TokenamiProperties] = value;
         if (propertyConfig.isCalc) (styles as any)[calcToggle] = '/**/';
@@ -407,12 +423,24 @@ function parseComposeBlocks(
   return parsedComposeBlocks;
 }
 
+const CSS_WIDE_KEYWORDS = new Set(['inherit', 'initial', 'unset', 'revert', 'revert-layer']);
+
+function isCSSWideKeyword(value: unknown) {
+  return typeof value === 'string' && CSS_WIDE_KEYWORDS.has(value);
+}
+
+function isGridProperty(cssProperty: string, config: Tokenami.Config) {
+  const customConfig = config.customProperties?.[cssProperty];
+  const propertyConfig = config.properties?.[cssProperty];
+  return customConfig?.includes('grid') ?? propertyConfig?.includes('grid') ?? false;
+}
+
 /* -------------------------------------------------------------------------------------------------
  * getPropertySelectors
  * -----------------------------------------------------------------------------------------------*/
 
 function getPropertySelectors(
-  composeBlocks: Record<`.${string}`, TokenamiProperties>,
+  composeBlocks: ComposeBlocks,
   prop: PropertyConfig,
   selectorConfig: string[]
 ) {
@@ -442,7 +470,7 @@ function getPropertySelectors(
  * -----------------------------------------------------------------------------------------------*/
 
 function getBaseSelectors(
-  composeBlocks: Record<`.${string}`, TokenamiProperties>,
+  composeBlocks: ComposeBlocks,
   property: Tokenami.TokenProperty
 ): string[] {
   const composeSelectors = Object.entries(composeBlocks).flatMap(([selector, styles]) => {
@@ -551,9 +579,8 @@ function getPropertyConfigs(
       const tokenProperty = Tokenami.parseProperty(longhandProperty);
       const currentConfigs = propertyConfigs.get(cssProperty as any) || [];
       const customConfig = config.customProperties?.[cssProperty];
-      const propertyConfig = config.properties?.[cssProperty];
       const isLogical = Supports.supportedLogicalProperties.has(cssProperty as any);
-      const isGrid = customConfig?.includes('grid') ?? propertyConfig?.includes('grid') ?? false;
+      const isGrid = isGridProperty(cssProperty, config);
       const isCustom = Boolean(customConfig);
       const layer = parts.variant
         ? `${isLogical ? LAYERS.SELECTORS_LOGICAL : LAYERS.SELECTORS}${layerIndex}`

--- a/packages/@tokenami-node/src/sheet.ts
+++ b/packages/@tokenami-node/src/sheet.ts
@@ -389,31 +389,28 @@ function parseComposeBlocks(composeBlocks: ComposeBlocks, config: Tokenami.Confi
     for (let [key, value, propertyConfig] of aliasProperties) {
       const tokenProperty = key as Tokenami.TokenProperty;
       const parts = Tokenami.getTokenPropertySplit(tokenProperty);
+      const shouldUseBaseProperty = parts.variants.length === 0 && isCSSWideKeyword(value);
 
       for (const cssProperty of propertyConfig.cssProperties) {
         const longProperty = Tokenami.createLonghandProperty(tokenProperty, cssProperty);
         const parsedProperty = Tokenami.parseProperty(longProperty);
         const calcToggle = Tokenami.calcProperty(parsedProperty);
-        const shouldUseBaseProperty = parts.variants.length === 0 && isCSSWideKeyword(value);
 
         if (shouldUseBaseProperty) {
           const isGrid = isGridProperty(cssProperty, config);
-          const propertyValue = isGrid
-            ? createGridPropertyValue(parsedProperty, value)
-            : createBasePropertyValue(parsedProperty, value);
-
-          styles[cssProperty] = propertyValue;
+          let propertyValue = createBasePropertyValue(parsedProperty, value);
 
           if (isGrid) {
             const hashGridProperty = hashVariantProperty('grid', parsedProperty);
+            propertyValue = createGridPropertyValue(parsedProperty, value);
             styles[hashGridProperty] = createGridToggleValue(parsedProperty);
           }
 
-          continue;
+          styles[cssProperty] = propertyValue;
+        } else {
+          styles[parsedProperty as keyof TokenamiProperties] = value;
+          if (propertyConfig.isCalc) (styles as any)[calcToggle] = '/**/';
         }
-
-        styles[parsedProperty as keyof TokenamiProperties] = value;
-        if (propertyConfig.isCalc) (styles as any)[calcToggle] = '/**/';
       }
     }
 


### PR DESCRIPTION
## Summary
- emit CSS-wide composed values like inherit as native properties with Tokenami custom-property fallbacks in @tokenami/node
- preserve grid-backed calc overrides through generated grid wrapper variables
- keep selector variants as direct property overrides instead of custom-property rewrites

## Tests
- pnpm --filter @tokenami/node test -- sheet