### PR TITLE
move type declarations into css package 

### DIFF
--- a/examples/design-system/.tokenami/tokenami.env.d.ts
+++ b/examples/design-system/.tokenami/tokenami.env.d.ts
@@ -2,6 +2,6 @@ import config from './tokenami.config.js';
 
 export type Config = typeof config;
 
-declare module 'tokenami' {
+declare module '@tokenami/css' {
   interface TokenamiConfig extends Config {}
 }

--- a/examples/nextjs/.tokenami/tokenami.env.d.ts
+++ b/examples/nextjs/.tokenami/tokenami.env.d.ts
@@ -2,6 +2,6 @@ import config from './tokenami.config.js';
 
 export type Config = typeof config;
 
-declare module 'tokenami' {
+declare module '@tokenami/css' {
   interface TokenamiConfig extends Config {}
 }

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "dev:nextjs": "turbo run dev:app dev:css --filter=@tokenami/example-nextjs",
     "build": "pnpm run \"/build:/\"",
     "build:tokenami": "turbo run build --filter=./packages/** --filter=./examples/design-system",
-    "build:types": "tsx ./packages/@tokenami-node/scripts/generate-declarations.ts",
+    "build:types": "tsx ./packages/@tokenami-css/scripts/generate-declarations.ts",
     "clean": "pnpm exec rm -rf node_modules .turbo && pnpm -r exec rm -rf node_modules .turbo dist",
     "typecheck": "turbo run typecheck",
     "test": "turbo run test",

--- a/packages/@tokenami-css/.tokenami/tokenami.env.d.ts
+++ b/packages/@tokenami-css/.tokenami/tokenami.env.d.ts
@@ -2,6 +2,6 @@ import config from './tokenami.config';
 
 export type Config = typeof config;
 
-declare module 'tokenami' {
+declare module '../src/declarations' {
   interface TokenamiConfig extends Config {}
 }

--- a/packages/@tokenami-css/package.json
+++ b/packages/@tokenami-css/package.json
@@ -34,16 +34,15 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@tokenami/config": "workspace:*"
+    "@tokenami/config": "workspace:*",
+    "csstype": "^3.1.2"
   },
   "devDependencies": {
-    "tokenami": "workspace:*",
     "tsup": "^8.4.0",
     "typescript": "^5.1.3",
     "vitest": "^3.2.6"
   },
   "peerDependencies": {
-    "tokenami": ">= 0",
     "typescript": ">= 5"
   }
 }

--- a/packages/@tokenami-css/scripts/generate-declarations.ts
+++ b/packages/@tokenami-css/scripts/generate-declarations.ts
@@ -1,6 +1,9 @@
 import fs from 'node:fs';
-import * as supports from '../src/supports';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+import * as supports from '../../@tokenami-node/src/supports';
 
+const __dirname = dirname(fileURLToPath(import.meta.url));
 const properties = [...supports.supportedProperties];
 
 const toPascalCase = (str: string) => {
@@ -54,7 +57,8 @@ import type * as Tokenami from '@tokenami/config';
 type Merge<A, B> = B extends never ? A : Omit<A, keyof B> & B;
 
 // consumer will override this interface
-interface TokenamiConfig {}
+export interface TokenamiConfig {}
+
 interface TokenamiFinalConfig extends Merge<Tokenami.Config, TokenamiConfig> {}
 
 type ThemeConfig = TokenamiFinalConfig['theme'];
@@ -180,7 +184,6 @@ type TokenamiPropertiesOmit<P extends keyof SupportedTokenPropertiesMap> = Omit<
   : never;
 
 export type {
-  TokenamiConfig,
   TokenamiFinalConfig,
   TokenamiProperties,
   TokenamiPropertiesPick,
@@ -189,6 +192,6 @@ export type {
 };
 `;
 
-fs.writeFileSync('./packages/@tokenami-node/src/declarations.ts', fileContent);
+fs.writeFileSync(join(__dirname, '../src/declarations.ts'), fileContent);
 console.log('File written successfully');
 console.log('Total properties:', properties.length);

--- a/packages/@tokenami-css/src/css.ts
+++ b/packages/@tokenami-css/src/css.ts
@@ -1,4 +1,4 @@
-import type { TokenamiProperties } from 'tokenami';
+import type { TokenamiProperties } from './declarations';
 import * as Tokenami from '@tokenami/config';
 
 const _TOKENAMI_CSS = Symbol.for('@tokenami/css');

--- a/packages/@tokenami-css/src/declarations.ts
+++ b/packages/@tokenami-css/src/declarations.ts
@@ -5,7 +5,8 @@ import type * as Tokenami from '@tokenami/config';
 type Merge<A, B> = B extends never ? A : Omit<A, keyof B> & B;
 
 // consumer will override this interface
-interface TokenamiConfig {}
+export interface TokenamiConfig {}
+
 interface TokenamiFinalConfig extends Merge<Tokenami.Config, TokenamiConfig> {}
 
 type ThemeConfig = TokenamiFinalConfig['theme'];
@@ -2023,7 +2024,6 @@ type TokenamiPropertiesOmit<P extends keyof SupportedTokenPropertiesMap> = Omit<
   : never;
 
 export type {
-  TokenamiConfig,
   TokenamiFinalConfig,
   TokenamiProperties,
   TokenamiPropertiesPick,

--- a/packages/@tokenami-css/src/index.ts
+++ b/packages/@tokenami-css/src/index.ts
@@ -1,9 +1,9 @@
-import { type TokenamiProperties } from 'tokenami';
+import { type TokenamiProperties } from './declarations';
 import { type TokenamiCSS, type TokenamiComposeOutput, type Variants as CSSVariants } from './css';
 
 export type TokenamiStyle<P> = P & { style?: TokenamiProperties | TokenamiCSS };
 export type Variants<T> = T extends TokenamiComposeOutput<infer V> ? CSSVariants<V> : {};
 
-export type { TokenamiProperties, TokenValue } from 'tokenami';
+export type { TokenamiConfig, TokenamiProperties, TokenValue } from './declarations';
 export { type Config, createConfig } from '@tokenami/config';
 export { type TokenamiCSS, createCss, css } from './css';

--- a/packages/@tokenami-css/tsconfig.json
+++ b/packages/@tokenami-css/tsconfig.json
@@ -9,8 +9,7 @@
     "paths": {
       "@tokenami/config": ["../@tokenami-config/src"],
       "@tokenami/node": ["../@tokenami-node/src"],
-      "@tokenami/node/ts-plugin": ["../@tokenami-node/src/ts-plugin"],
-      "tokenami": ["../tokenami/src"]
+      "@tokenami/node/ts-plugin": ["../@tokenami-node/src/ts-plugin"]
     }
   }
 }

--- a/packages/@tokenami-node/src/index.ts
+++ b/packages/@tokenami-node/src/index.ts
@@ -1,4 +1,3 @@
-export type * from './declarations';
 export * from './core';
 export * from './ts-plugin';
 export * as log from './log';

--- a/packages/@tokenami-node/src/sheet.ts
+++ b/packages/@tokenami-node/src/sheet.ts
@@ -1,6 +1,5 @@
 import * as Tokenami from '@tokenami/config';
 import { stringify } from '@stitches/stringify';
-import { type TokenamiProperties } from './declarations';
 import { type ComposeBlocks } from './core';
 import * as utils from './utils';
 import * as Supports from './supports';
@@ -417,7 +416,7 @@ function parseComposeBlocks(composeBlocks: ComposeBlocks, config: Tokenami.Confi
 
           styles[cssProperty] = propertyValue;
         } else {
-          styles[parsedProperty as keyof TokenamiProperties] = value;
+          styles[parsedProperty] = value;
           if (propertyConfig.isCalc) (styles as any)[calcToggle] = '/**/';
         }
       }
@@ -480,7 +479,7 @@ function getBaseSelectors(
   property: Tokenami.TokenProperty
 ): string[] {
   const composeSelectors = Object.entries(composeBlocks).flatMap(([selector, styles]) => {
-    return styles[property as keyof TokenamiProperties] !== undefined ? [selector] : [];
+    return styles[property] !== undefined ? [selector] : [];
   });
   return [DEFAULT_SELECTOR, ...composeSelectors];
 }

--- a/packages/@tokenami-node/stubs/tokenami.env.d.ts
+++ b/packages/@tokenami-node/stubs/tokenami.env.d.ts
@@ -2,6 +2,6 @@ import config from './tokenami.config.js';
 
 export type Config = typeof config;
 
-declare module 'tokenami' {
+declare module '@tokenami/css' {
   interface TokenamiConfig extends Config {}
 }

--- a/packages/tokenami/src/index.ts
+++ b/packages/tokenami/src/index.ts
@@ -13,4 +13,3 @@ function tokenami(mod: TypeScriptPluginModule) {
 }
 
 export default tokenami;
-export type * from '@tokenami/node';

--- a/packages/tokenami/tsconfig.json
+++ b/packages/tokenami/tsconfig.json
@@ -9,8 +9,7 @@
     "target": "ES2022",
     "paths": {
       "@tokenami/node": ["../@tokenami-node/src"],
-      "@tokenami/node/ts-plugin": ["../@tokenami-node/src/ts-plugin"],
-      "@tokenami/css": ["../@tokenami-css/src"] // used in stubs
+      "@tokenami/node/ts-plugin": ["../@tokenami-node/src/ts-plugin"]
     }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -67,14 +67,14 @@ importers:
         version: 19.1.9(@types/react@19.1.13)
       react:
         specifier: ^16.8 || ^17.0 || ^18.0
-        version: 19.1.1
+        version: 18.3.1
       react-dom:
         specifier: ^16.8 || ^17.0 || ^18.0
-        version: 19.1.1(react@19.1.1)
+        version: 18.3.1(react@18.3.1)
     devDependencies:
       '@storylite/storylite':
         specifier: ^0.14.0
-        version: 0.14.0(@types/node@25.9.3)(@types/react-dom@19.1.9(@types/react@19.1.13))(@types/react@19.1.13)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(typescript@5.4.5)
+        version: 0.14.0(@types/node@25.9.3)(@types/react-dom@19.1.9(@types/react@19.1.13))(@types/react@19.1.13)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.4.5)
       '@storylite/vite-plugin':
         specifier: ^0.14.0
         version: 0.14.0(@types/node@25.9.3)(jiti@2.4.2)(lightningcss@1.29.1)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)
@@ -204,10 +204,10 @@ importers:
       '@tokenami/config':
         specifier: workspace:*
         version: link:../@tokenami-config
+      csstype:
+        specifier: ^3.1.2
+        version: 3.1.3
     devDependencies:
-      tokenami:
-        specifier: workspace:*
-        version: link:../tokenami
       tsup:
         specifier: ^8.4.0
         version: 8.4.0(@swc/core@1.15.41)(jiti@2.4.2)(postcss@8.5.15)(tsx@4.21.0)(typescript@5.4.5)(yaml@2.9.0)
@@ -6738,7 +6738,10 @@ snapshots:
     dependencies:
       '@percy/cli-command': 1.31.14(typescript@5.4.5)
     transitivePeerDependencies:
+      - bufferutil
+      - supports-color
       - typescript
+      - utf-8-validate
 
   '@percy/cli-command@1.31.14(typescript@5.4.5)':
     dependencies:
@@ -6755,7 +6758,10 @@ snapshots:
     dependencies:
       '@percy/cli-command': 1.31.14(typescript@5.4.5)
     transitivePeerDependencies:
+      - bufferutil
+      - supports-color
       - typescript
+      - utf-8-validate
 
   '@percy/cli-doctor@1.31.14(typescript@5.4.5)':
     dependencies:
@@ -6791,7 +6797,10 @@ snapshots:
       '@percy/cli-command': 1.31.14(typescript@5.4.5)
       yaml: 2.9.0
     transitivePeerDependencies:
+      - bufferutil
+      - supports-color
       - typescript
+      - utf-8-validate
 
   '@percy/cli-upload@1.31.14(typescript@5.4.5)':
     dependencies:
@@ -6799,7 +6808,10 @@ snapshots:
       fast-glob: 3.3.3
       image-size: 1.2.1
     transitivePeerDependencies:
+      - bufferutil
+      - supports-color
       - typescript
+      - utf-8-validate
 
   '@percy/cli@1.31.14(typescript@5.4.5)':
     dependencies:
@@ -7177,16 +7189,16 @@ snapshots:
 
   '@stitches/stringify@1.2.8': {}
 
-  '@storylite/storylite@0.14.0(@types/node@25.9.3)(@types/react-dom@19.1.9(@types/react@19.1.13))(@types/react@19.1.13)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(typescript@5.4.5)':
+  '@storylite/storylite@0.14.0(@types/node@25.9.3)(@types/react-dom@19.1.9(@types/react@19.1.13))(@types/react@19.1.13)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.4.5)':
     dependencies:
       '@types/node': 25.9.3
       '@types/react': 19.1.13
       '@types/react-dom': 19.1.9(@types/react@19.1.13)
       clsx: 2.1.1
-      react: 19.1.1
-      react-dom: 19.1.1(react@19.1.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
       typescript: 5.4.5
-      zustand: 4.5.2(@types/react@19.1.13)(react@19.1.1)
+      zustand: 4.5.2(@types/react@19.1.13)(react@18.3.1)
     transitivePeerDependencies:
       - immer
 
@@ -10739,9 +10751,9 @@ snapshots:
 
   url-join@4.0.1: {}
 
-  use-sync-external-store@1.2.0(react@19.1.1):
+  use-sync-external-store@1.2.0(react@18.3.1):
     dependencies:
-      react: 19.1.1
+      react: 18.3.1
 
   use-sync-external-store@1.4.0(react@19.1.1):
     dependencies:
@@ -11208,9 +11220,9 @@ snapshots:
 
   yoctocolors-cjs@2.1.3: {}
 
-  zustand@4.5.2(@types/react@19.1.13)(react@19.1.1):
+  zustand@4.5.2(@types/react@19.1.13)(react@18.3.1):
     dependencies:
-      use-sync-external-store: 1.2.0(react@19.1.1)
+      use-sync-external-store: 1.2.0(react@18.3.1)
     optionalDependencies:
       '@types/react': 19.1.13
-      react: 19.1.1
+      react: 18.3.1

--- a/visual-tests/tokenami/.tokenami/tokenami.env.d.ts
+++ b/visual-tests/tokenami/.tokenami/tokenami.env.d.ts
@@ -2,6 +2,6 @@ import config from './tokenami.config.js';
 
 export type Config = typeof config;
 
-declare module 'tokenami' {
+declare module '@tokenami/css' {
   interface TokenamiConfig extends Config {}
 }


### PR DESCRIPTION
# Summary

## Change Type

<!-- Please indicate the type of change this is -->

- [ ] `documentation`
- [x] `patch`
- [ ] `minor`
- [ ] `major`

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.0.99--canary.513.27862221791.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @tokenami/example-design-system@0.0.99--canary.513.27862221791.0
  npm install @tokenami/example-nextjs@0.0.99--canary.513.27862221791.0
  npm install @tokenami/cli@0.0.99--canary.513.27862221791.0
  npm install @tokenami/config@0.0.99--canary.513.27862221791.0
  npm install @tokenami/css@0.0.99--canary.513.27862221791.0
  npm install @tokenami/ds@0.0.99--canary.513.27862221791.0
  npm install @tokenami/node@0.0.99--canary.513.27862221791.0
  npm install @tokenami/unplugin@0.0.99--canary.513.27862221791.0
  npm install tokenami@0.0.99--canary.513.27862221791.0
  # or 
  yarn add @tokenami/example-design-system@0.0.99--canary.513.27862221791.0
  yarn add @tokenami/example-nextjs@0.0.99--canary.513.27862221791.0
  yarn add @tokenami/cli@0.0.99--canary.513.27862221791.0
  yarn add @tokenami/config@0.0.99--canary.513.27862221791.0
  yarn add @tokenami/css@0.0.99--canary.513.27862221791.0
  yarn add @tokenami/ds@0.0.99--canary.513.27862221791.0
  yarn add @tokenami/node@0.0.99--canary.513.27862221791.0
  yarn add @tokenami/unplugin@0.0.99--canary.513.27862221791.0
  yarn add tokenami@0.0.99--canary.513.27862221791.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
