### PR TITLE
reduce arbitrary selector specificity

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@
   - [Breakpoints](#user-content-breakpoints)
   - [Animation](#user-content-animation)
 - [Advanced usage](#user-content-advanced-usage)
-  - [Custom selectors](#user-content-custom-selectors)
+  - [Named selectors](#user-content-named-selectors)
   - [Property aliases](#user-content-property-aliases)
   - [Theming properties](#user-content-theming-properties)
   - [Custom properties](#user-content-custom-properties)
@@ -222,15 +222,17 @@ Benefits include:
 
 Utility-first solutions (like Tailwind) and CSS-in-JS both eventually run into the same challenge: composition. As reusable styles, variants, overrides, and composition across component boundaries accumulate, ensuring styles compose predictably without cascade or specificity issues becomes increasingly difficult.
 
-Tokenami is a styling toolkit for teams building design systems that need to scale without specificity creep. It provides first-class primitives for [component styles](#user-content-composing-components), [utilities](#user-content-css-utility), [variants](#user-content-variants), [selectors](#user-content-custom-selectors), and [overrides](#user-content-overrides), while keeping styles colocated with the components that use them.
+Tokenami is a styling toolkit for teams building design systems that need to scale without specificity creep. It provides first-class primitives for [component styles](#user-content-composing-components), [utilities](#user-content-css-utility), [variants](#user-content-variants), [selectors](#user-content-named-selectors), and [overrides](#user-content-overrides), while keeping styles colocated with the components that use them.
 
-It extracts what can live in the stylesheet, leaves dynamic values inline when needed, and _manages the cascade for you_. Define selector order once in your config, then compose styles and use complex selectors without having to think about the cascade or specificity again.
+It extracts what can live in the stylesheet, leaves dynamic values inline when needed, and _manages the cascade for you_. Name selectors and order them once in your config, then compose styles with complex selectors without having to think about the cascade or specificity again.
 
 ### Why CSS variables?
 
 Tokenami uses CSS variables because they let inline styles do more than inline styles normally can.
 
-A variable like `--padding` maps directly to the CSS property you already know, while prefixes like `--hover_color` or `--md_padding` add pseudo-classes and breakpoints. Tokenami can pass those values inline, then let the generated stylesheet decide when they apply.
+A variable like `--padding` maps directly to the CSS property you already know, while named selector
+prefixes like `--hover_color` and breakpoint prefixes like `--md_padding` decide when values apply.
+Tokenami can pass those values inline, then let the generated stylesheet handle the cascade.
 
 Those selectors are powered by [CSS variable toggles](#user-content-selector-specificity), so selector complexity does not turn into higher specificity.
 
@@ -344,6 +346,10 @@ Use arbitrary selectors to prototype quickly:
 ```
 
 They can be used to style the **current element, and its descendants** only.
+
+Arbitrary selectors are intended for one-off local selectors. They have lower priority than
+[named selectors](#user-content-named-selectors). If ordering matters, promote the selector to
+your config.
 
 ### Arbitrary values
 
@@ -634,9 +640,11 @@ Apply the animation to an element:
 
 Tokenami has some advanced features that can help you build more powerful design systems.
 
-### Custom selectors
+### Named selectors
 
-Some [common selectors](https://github.com/tokenami/tokenami/blob/main/packages/@tokenami-node/stubs/tokenami.config.ts#L28) are included, but you can configure your own. Use the ampersand (`&`) to mark where the current element's selector should be injected:
+Named selectors let you give complex selectors simple names and controls their override order. Some [common selectors](https://github.com/tokenami/tokenami/blob/main/packages/@tokenami-node/stubs/tokenami.config.ts#L34)
+are included, but you can configure your own. Use the ampersand (`&`) to mark where the current
+element's selector should be injected:
 
 ```ts
 export default createConfig({
@@ -659,7 +667,10 @@ Use them in your components:
 
 #### Selector specificity
 
-Tokenami selectors are [CSS variable toggles](https://css-tricks.com/the-css-custom-property-toggle-trick/), so properties like `--hover_color` have a `--_hover` toggle that activates when your selector matches. Because of that, **selector complexity does not increase specificity**. You can make selectors as elaborate as you need without fighting the cascade.
+Tokenami selectors are [CSS variable toggles](https://css-tricks.com/the-css-custom-property-toggle-trick/),
+so properties like `--hover_color` have a `--hover` toggle that activates when your selector
+matches. Because of that, **selector complexity does not increase specificity**. You can make named
+selectors as elaborate as you need without fighting the cascade.
 
 For example, the [official design system](https://github.com/tokenami/tokenami/blob/main/packages/@tokenami-ds/src/index.ts) uses a `hover` selector that only applies on fine pointers and skips disabled elements:
 

--- a/packages/@tokenami-node/src/sheet.test.ts
+++ b/packages/@tokenami-node/src/sheet.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest';
+import * as Tokenami from '@tokenami/config';
 import type { Config } from '@tokenami/config';
 import { createSheet } from './sheet';
 
@@ -17,6 +18,7 @@ const testConfig: Config = {
   grid: '0.25rem',
   selectors: {
     hover: '&:hover',
+    focus: '&:focus',
   },
 };
 
@@ -91,4 +93,85 @@ describe('sheet', () => {
     );
     expect(sheet).not.toMatch(/@layer tkc\s*{\s*\.tk-child\s*{\s*--block-size: inherit/);
   });
+
+  it('orders named selector overrides by config order', () => {
+    const sheet1 = createSheet({
+      config: testConfig,
+      tokens: {
+        properties: ['--focus_color', '--hover_color'],
+        values: [],
+        composeBlocks: {},
+      },
+    });
+    const sheet2 = createSheet({
+      config: testConfig,
+      tokens: {
+        properties: ['--hover_color', '--focus_color'],
+        values: [],
+        composeBlocks: {},
+      },
+    });
+
+    const hoverProperty = variantProperty('hover', 'color');
+    const focusProperty = variantProperty('focus', 'color');
+    const result = `color: var(${focusProperty}, var(${hoverProperty}, revert-layer))`;
+
+    expect(sheet1).toContain(result);
+    expect(sheet2).toContain(result);
+  });
+
+  it('orders named selector overrides after arbitrary selector overrides', () => {
+    const sheet1 = createSheet({
+      config: testConfig,
+      tokens: {
+        properties: ['--hover_color', '--{&:hover}_color'],
+        values: [],
+        composeBlocks: {},
+      },
+    });
+    const sheet2 = createSheet({
+      config: testConfig,
+      tokens: {
+        properties: ['--{&:hover}_color', '--hover_color'],
+        values: [],
+        composeBlocks: {},
+      },
+    });
+
+    const arbitraryProperty = variantProperty('{&:hover}', 'color');
+    const hoverProperty = variantProperty('hover', 'color');
+    const result = `color: var(${hoverProperty}, var(${arbitraryProperty}, revert-layer))`;
+
+    expect(sheet1).toContain(result);
+    expect(sheet2).toContain(result);
+  });
+
+  it('orders arbitrary selector overrides deterministically', () => {
+    const firstSheet = createSheet({
+      config: testConfig,
+      tokens: {
+        properties: ['--{&:focus}_color', '--{&:hover}_color'],
+        values: [],
+        composeBlocks: {},
+      },
+    });
+    const secondSheet = createSheet({
+      config: testConfig,
+      tokens: {
+        properties: ['--{&:hover}_color', '--{&:focus}_color'],
+        values: [],
+        composeBlocks: {},
+      },
+    });
+
+    expect(getColorDeclaration(firstSheet)).toEqual(getColorDeclaration(secondSheet));
+  });
 });
+
+function variantProperty(variant: string, property: string) {
+  return `--_${Tokenami.hash(variant + property)}`;
+}
+
+function getColorDeclaration(sheet: string) {
+  return sheet.match(/color: var\(--_[^;}]+/)?.[0];
+}

--- a/packages/@tokenami-node/src/sheet.ts
+++ b/packages/@tokenami-node/src/sheet.ts
@@ -575,7 +575,8 @@ function getPropertyConfigs(
     const properties = Tokenami.getCSSPropertiesForAlias(parts.alias, config.aliases);
     const responsiveOrder = parts.responsive ? 1 : 0;
     const selectorOrder = parts.selector ? 2 : 0;
-    const order = responsiveOrder + selectorOrder;
+    const selectorRank = getSelectorRank(parts.selector, config);
+    const order = responsiveOrder + selectorOrder + selectorRank;
 
     for (const cssProperty of properties) {
       const layerIndex = getPropertyLayerIndex(cssProperty, config);
@@ -600,6 +601,29 @@ function getPropertyConfigs(
   }
 
   return propertyConfigs;
+}
+
+/* -------------------------------------------------------------------------------------------------
+ * getSelectorRank
+ * -----------------------------------------------------------------------------------------------*/
+
+function getSelectorRank(selector: string | undefined, config: Tokenami.Config): number {
+  const arbitrarySelector = Tokenami.getArbitrarySelector(selector);
+  if (arbitrarySelector) return getArbitrarySelectorRank(arbitrarySelector);
+  if (!selector) return 0;
+
+  const selectorIndex = Object.keys(config.selectors || {}).indexOf(selector);
+  return selectorIndex === -1 ? 0 : (selectorIndex + 1) / 1000;
+}
+
+/* -------------------------------------------------------------------------------------------------
+ * getArbitrarySelectorRank
+ * -----------------------------------------------------------------------------------------------*/
+
+function getArbitrarySelectorRank(selector: string): number {
+  const hash = Tokenami.hash(selector);
+  const value = parseInt(hash, 36);
+  return value / 36 ** hash.length / 1000;
 }
 
 /* -------------------------------------------------------------------------------------------------

--- a/visual-tests/tokenami/src/tokenami.css
+++ b/visual-tests/tokenami/src/tokenami.css
@@ -1,1 +1,744 @@
-@layer global{:root{--font-family:ui-sans-serif,system-ui,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol","Noto Color Emoji";--font-stretch:normal;--font-style:normal;--font-variant:normal;--font-weight:normal}*,:before,:after{box-sizing:border-box;border:0;margin:0;padding:0}html,:host{-webkit-text-size-adjust:100%;tab-size:4;line-height:1.5;font-family:var(--font-family);font-feature-settings:normal;font-variation-settings:normal;-webkit-tap-highlight-color:transparent}body{line-height:inherit}hr{height:0;color:inherit;border-top-width:1px}abbr:where([title]){text-decoration:underline dotted}h1,h2,h3,h4,h5,h6{font-size:inherit;font-weight:inherit}a{color:inherit;text-decoration:inherit}b,strong{font-weight:bolder}code,kbd,samp,pre{--font-family:ui-monospace,SFMono-Regular,Menlo,Monaco,Consolas,"Liberation Mono","Courier New",monospace;font-family:var(--font-family);font-feature-settings:normal;font-variation-settings:normal;font-size:1em}small{font-size:80%}sub,sup{vertical-align:baseline;font-size:75%;line-height:0;position:relative}sub{bottom:-.25em}sup{top:-.5em}table{text-indent:0;border-color:inherit;border-collapse:collapse}button,input,optgroup,select,textarea{font:inherit;font-feature-settings:inherit;font-variation-settings:inherit;letter-spacing:inherit;color:inherit;background:0 0}::file-selector-button{font:inherit;font-feature-settings:inherit;font-variation-settings:inherit;letter-spacing:inherit;color:inherit;background:0 0}input:where(:not([type=button],[type=reset],[type=submit])),select,textarea{border:1px solid}button,input:where([type=button]),input:where([type=reset]),input:where([type=submit]){appearance:button}::file-selector-button{appearance:button}:-moz-focusring{outline:auto}:-moz-ui-invalid{box-shadow:none}progress{vertical-align:baseline}::-webkit-inner-spin-button{height:auto}::-webkit-outer-spin-button{height:auto}::-webkit-search-decoration{-webkit-appearance:none}summary{display:list-item}ol,ul,menu{list-style:none}textarea{resize:vertical}::placeholder{opacity:1;color:color-mix(in srgb,currentColor 50%,transparent)}img,svg,video,canvas,audio,iframe,embed,object{vertical-align:middle;display:block}[hidden]:not([hidden=until-found]){display:none}}@layer tkb{@keyframes pulse{0%,to{opacity:1}50%{opacity:.5}}@keyframes wiggle{0%,to{transform:rotate(-3deg)}50%{transform:rotate(3deg)}}:root{--_grid:.25rem;--anim_pulse:pulse 2s cubic-bezier(.4,0,.6,1)infinite;--anim_wiggle:wiggle 1s ease-in-out infinite;--font_mono:ui-monospace,SFMono-Regular,Menlo,Monaco,Consolas,"Liberation Mono","Courier New",monospace;--font_sans:ui-sans-serif,system-ui,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol","Noto Color Emoji";--leading_7:1.75rem;--leading_loose:2;--line-size_4:.25rem;--line_0:0 solid;--line_8:.5rem solid;--line_px:.0625rem solid;--morph_all:all cubic-bezier(.4,0,.2,1).15s;--radii_3xl:1.5rem;--radii_full:9999px;--radii_lg:.5rem;--radii_none:0;--radii_sm:.125rem;--radii_xl:.75rem;--size_auto:auto;--size_half:50%;--size_screen-h:100vh;--text-size_4xl:2.25rem;--text-size_lg:1.125rem;--text-size_xl:1.25rem;--weight_medium:500}:root,:root [style],:root .tk-utbdlz,:root [style]>p,:root [style*=selection_],:root [style] p,:root [style] .card,:root .tk-erz9s7,:root .tk-rychtn{--gradient_to-b:linear-gradient(to bottom in var(--_color-space,srgb),var(--_gradient-from)var(--_gradient-from-stop, ),var(---via,var(--_gradient-to)var(--_gradient-to-stop, )));---via:var(--_gradient-via)var(--_gradient-via-stop, ),var(--_gradient-to);--text_base:var(--font-stretch)var(--font-style)var(--font-variant)var(--font-weight)1rem/1.5rem var(--font-family);--text_xl:var(--font-stretch)var(--font-style)var(--font-variant)var(--font-weight)1.25rem/1.75rem var(--font-family)}:root,[data-theme=light]{--color_amber12:#4f3422;--color_amber8:#e2a336;--color_amber9:#ffc442;--color_gray10:#838383;--color_gray11:#646464;--color_gray7:#cecece;--color_gray8:#bbb;--color_green9:#30a46c;--color_indigo10:#3358d4;--color_indigo5:#d2deff;--color_indigo6:#c1d0ff;--color_indigo8:#8da4ef;--color_iris10:#5151cd;--color_red10:#dd3e42;--color_red8:#eb8e90;--color_red9:#e5484d;--color_violet10:#654dc4;--color_violet11:#6550b9;--color_violet9:#6e56cf;--color_white:#fff;--pet_favourite:"🐶"}@supports (color:color(display-p3 0 0 0)){:root,[data-theme=light]{--color_amber12:color(display-p3 .294 .208 .145);--color_amber8:color(display-p3 .85 .65 .3);--color_amber9:color(display-p3 1 .77 .26);--color_gray10:color(display-p3 .512 .512 .512);--color_gray11:color(display-p3 .392 .392 .392);--color_gray7:color(display-p3 .807 .807 .807);--color_gray8:color(display-p3 .732 .732 .732);--color_green9:color(display-p3 .332 .634 .442);--color_indigo10:color(display-p3 .234 .343 .801);--color_indigo5:color(display-p3 .831 .87 1);--color_indigo6:color(display-p3 .767 .814 .995);--color_indigo8:color(display-p3 .569 .639 .916);--color_iris10:color(display-p3 .318 .318 .774);--color_red10:color(display-p3 .798 .294 .285);--color_red8:color(display-p3 .872 .575 .572);--color_red9:color(display-p3 .83 .329 .324);--color_violet10:color(display-p3 .381 .306 .741);--color_violet11:color(display-p3 .383 .317 .702);--color_violet9:color(display-p3 .417 .341 .784);--color_white:color(display-p3 1 1 1)}}[data-theme=dark]{--color_amber12:#ffe7b3;--color_amber8:#8f6424;--color_amber9:#ffc442;--color_gray10:#7b7b7b;--color_gray11:#b4b4b4;--color_gray7:#484848;--color_gray8:#606060;--color_green9:#30a46c;--color_indigo10:#5472e4;--color_indigo5:#253974;--color_indigo6:#304384;--color_indigo8:#435db2;--color_iris10:#6e6ade;--color_red10:#ec5e5e;--color_red8:#b54548;--color_red9:#e5484d;--color_violet10:#7d66d9;--color_violet11:#bba6ff;--color_violet9:#6e56cf;--color_white:#fff;--pet_favourite:"🐱"}@supports (color:color(display-p3 0 0 0)){[data-theme=dark]{--color_amber12:color(display-p3 .984 .909 .726);--color_amber8:color(display-p3 .535 .399 .189);--color_amber9:color(display-p3 1 .77 .26);--color_gray10:color(display-p3 .484 .484 .484);--color_gray11:color(display-p3 .706 .706 .706);--color_gray7:color(display-p3 .283 .283 .283);--color_gray8:color(display-p3 .375 .375 .375);--color_green9:color(display-p3 .332 .634 .442);--color_indigo10:color(display-p3 .354 .445 .866);--color_indigo5:color(display-p3 .163 .22 .439);--color_indigo6:color(display-p3 .203 .262 .5);--color_indigo8:color(display-p3 .285 .362 .674);--color_iris10:color(display-p3 .428 .416 .843);--color_red10:color(display-p3 .861 .403 .387);--color_red8:color(display-p3 .659 .298 .297);--color_red9:color(display-p3 .83 .329 .324);--color_violet10:color(display-p3 .477 .402 .823);--color_violet11:color(display-p3 .72 .65 1);--color_violet9:color(display-p3 .417 .341 .784);--color_white:color(display-p3 1 1 1)}}*{--background-color:initial;--hover_background-color:initial;--hover:initial;--_1gqxh9p:initial;--child-p:initial;--_163r6xx:initial;--selection_background-color:initial;--selection:initial;--_9t0pqg:initial;--prose-p:initial;--_nf2ooy:initial;--prose-card:initial;--_134znwc:initial;--\{\&\;focus\;hover\}_background-color:initial;--\{\&\;focus\;hover\}:initial;--_aoiy32:initial;--border-block-end:initial;--border-block-color:initial;--border-inline-color:initial;--border-radius:initial;--md_border-radius:initial;--md:initial;--_1u7yt41:initial;--_d4svsr:initial;--inline-size:initial;--inline-size__calc:initial;--md_inline-size:initial;--md_inline-size__calc:initial;--_1imu60m:initial;--block-size:initial;--block-size__calc:initial;--md_block-size:initial;--md_block-size__calc:initial;--_qqcymk:initial;--transition:initial;--hover_animation:initial;--_xgpg9b:initial;--_xksefa:initial;--_ez0gpl:initial;--min-height:initial;--min-height__calc:initial;--background-size:initial;--background-image:initial;--background-position-x:initial;--background-position-x__calc:initial;--background-position-y:initial;--background-position-y__calc:initial;--display:initial;--md_display:initial;--_1loixh8:initial;--flex-direction:initial;--align-items:initial;--justify-content:initial;--padding-inline:initial;--padding-inline__calc:initial;--_1wrhsdd:initial;--position:initial;--before_position:initial;--before:initial;--_nej54n:initial;--z-index:initial;--before_z-index:initial;--_1f713oa:initial;--padding:initial;--padding__calc:initial;--md_padding:initial;--md_padding__calc:initial;--_1432d1p:initial;--margin:initial;--margin__calc:initial;--before_content:initial;--_16uwti7:initial;--after_content:initial;--after:initial;--_d9agn9:initial;--md_after_content:initial;--md_after:initial;--_1swegf4:initial;--before_inset:initial;--before_inset__calc:initial;--_1vokwbf:initial;--background:initial;--before_background:initial;--_rt68g4:initial;--before_gradient-from:initial;--_blthfh:initial;--before_gradient-to:initial;--_jkmljo:initial;--_18hd4n5:initial;--overflow:initial;--padding-block:initial;--padding-block__calc:initial;--justify-items:initial;--padding-block-start:initial;--padding-block-start__calc:initial;--xxl:initial;--_axuivf:initial;--margin-block-end:initial;--margin-block-end__calc:initial;--margin-inline:initial;--margin-inline__calc:initial;--margin-inline-start:initial;--margin-inline-start__calc:initial;--border:initial;--margin-block:initial;--margin-block__calc:initial;--border-start-start-radius:initial;--border-start-end-radius:initial;--margin-block-start:initial;--margin-block-start__calc:initial;--border-block-width:initial;--border-inline-width:initial;--object-fit:initial}@media (hover:hover) and (pointer:fine){[style]:not(:disabled):hover,.tk-utbdlz:not(:disabled):hover{--hover: }}[style]>p{--child-p: }[style*=selection_]{--selection: }[style] p{--prose-p: }[style] .card{--prose-card: }[style]:focus:hover,.tk-utbdlz:focus:hover{--\{\&\;focus\;hover\}: }@media (width>=48rem){[style]{--md: ;--md_after: }}[style]{--before: ;--after: }@media (width>=96rem){[style]{--xxl: }}}@layer tk1{[style]{font:var(--font,revert-layer);min-height:var(--_lmglzt,var(--min-height,revert-layer));--_lmglzt:var(--min-height__calc)calc(var(--min-height)*var(--_grid));display:var(--display,revert-layer);position:var(--position,revert-layer);z-index:var(--z-index,revert-layer);padding:var(--_443yf1,var(--padding,revert-layer));--_443yf1:var(--padding__calc)calc(var(--padding)*var(--_grid));margin:var(--_1ty9hq,var(--margin,revert-layer));--_1ty9hq:var(--margin__calc)calc(var(--margin)*var(--_grid));background:var(--background,revert-layer);text-align:var(--text-align,revert-layer);overflow:var(--overflow,revert-layer)}.tk-utbdlz,[style]{border-radius:var(--border-radius,revert-layer);transition:var(--transition,revert-layer);color:var(--color,revert-layer)}.tk-erz9s7,[style]{border:var(--border,revert-layer)}.tk-rychtn,[style]{object-fit:var(--object-fit,revert-layer)}}@layer tk2{[style]{font-family:var(--font-family,revert-layer);font-stretch:var(--font-stretch,revert-layer);font-style:var(--font-style,revert-layer);font-variant:var(--font-variant,revert-layer);font-weight:var(--font-weight,revert-layer);background-size:var(--background-size,revert-layer);background-image:var(--background-image,revert-layer);flex-direction:var(--flex-direction,revert-layer);align-items:var(--align-items,revert-layer);justify-content:var(--justify-content,revert-layer);justify-items:var(--justify-items,revert-layer);line-height:var(--line-height,revert-layer);font-size:var(--font-size,revert-layer);border-start-start-radius:var(--border-start-start-radius,revert-layer);border-start-end-radius:var(--border-start-end-radius,revert-layer)}.tk-utbdlz,[style]{background-color:var(--background-color,revert-layer)}}@layer tk3{[style]{background-position-x:var(--_j8nb15,var(--background-position-x,revert-layer));--_j8nb15:var(--background-position-x__calc)calc(var(--background-position-x)*var(--_grid));background-position-y:var(--_15wunjl,var(--background-position-y,revert-layer));--_15wunjl:var(--background-position-y__calc)calc(var(--background-position-y)*var(--_grid))}}@layer tkl1{.tk-utbdlz,[style]{inline-size:var(--_a9n10r,var(--inline-size,revert-layer));--_a9n10r:var(--inline-size__calc)calc(var(--inline-size)*var(--_grid));block-size:var(--_19kaxgm,var(--block-size,revert-layer));--_19kaxgm:var(--block-size__calc)calc(var(--block-size)*var(--_grid))}}@layer tkl2{[style]{padding-inline:var(--_twrjq1,var(--padding-inline,revert-layer));--_twrjq1:var(--padding-inline__calc)calc(var(--padding-inline)*var(--_grid));padding-block:var(--_11by1jg,var(--padding-block,revert-layer));--_11by1jg:var(--padding-block__calc)calc(var(--padding-block)*var(--_grid));margin-inline:var(--_2243e5,var(--margin-inline,revert-layer));--_2243e5:var(--margin-inline__calc)calc(var(--margin-inline)*var(--_grid));margin-block:var(--_1rd6zpk,var(--margin-block,revert-layer));--_1rd6zpk:var(--margin-block__calc)calc(var(--margin-block)*var(--_grid))}}@layer tkl3{[style]{--_193cv1f:var(--padding-block-start__calc)calc(var(--padding-block-start)*var(--_grid));--_rq4yuw:var(--margin-block-end__calc)calc(var(--margin-block-end)*var(--_grid));--_sn3kh4:var(--margin-inline-start__calc)calc(var(--margin-inline-start)*var(--_grid));--_1x10y43:var(--margin-block-start__calc)calc(var(--margin-block-start)*var(--_grid));margin-block-start:var(--_1x10y43,var(--margin-block-start,revert-layer));margin-block-end:var(--_rq4yuw,var(--margin-block-end,revert-layer));margin-inline-start:var(--_sn3kh4,var(--margin-inline-start,revert-layer));padding-block-start:var(--_193cv1f,var(--padding-block-start,revert-layer))}.tk-utbdlz,[style]{border-block-end:var(--border-block-end,revert-layer)}}@layer tkl5{[style]{border-block-width:var(--border-block-width,revert-layer);border-inline-width:var(--border-inline-width,revert-layer)}.tk-erz9s7,.tk-rychtn,.tk-utbdlz,[style]{border-block-color:var(--border-block-color,revert-layer);border-inline-color:var(--border-inline-color,revert-layer)}}@layer tks1{[style]{--_1u7yt41:var(--md)var(--md_border-radius);color:var(--_ez0gpl,revert-layer);--_ez0gpl:var(--hover)var(--hover_color);display:var(--_1loixh8,revert-layer);--_1loixh8:var(--md)var(--md_display);--_nej54n:var(--before)var(--before_position);--_1f713oa:var(--before)var(--before_z-index);padding:var(--_1432d1p,revert-layer);--_1432d1p:var(--md)var(--_6cxmw0,var(--md_padding));--_6cxmw0:var(--md_padding__calc)calc(var(--md_padding)*var(--_grid));--_16uwti7:var(--before)var(--before_content);--_d9agn9:var(--after)var(--after_content);--_1swegf4:var(--md_after)var(--md_after_content);--_1vokwbf:var(--before)var(--_a6shpi,var(--before_inset));--_a6shpi:var(--before_inset__calc)calc(var(--before_inset)*var(--_grid));--_rt68g4:var(--before)var(--before_background);--_gradient-from:var(--_blthfh,var(--gradient-from));--_blthfh:var(--before)var(--before_gradient-from);--_gradient-to:var(--_jkmljo,var(--gradient-to));--_jkmljo:var(--before)var(--before_gradient-to);text-align:var(--_18hd4n5,revert-layer);--_18hd4n5:var(--md)var(--md_text-align)}.tk-utbdlz,[style]{animation:var(--_xgpg9b,revert-layer);--_xgpg9b:var(--hover)var(--hover_animation)}[style]>p{--_d4svsr:var(--child-p)var(--child-p_border-radius)}[style*=selection_]::selection{color:var(--_xksefa,revert-layer)}[style*=selection_]{--_xksefa:var(--selection)var(--selection_color)}[style],[style]>p{border-radius:var(--_d4svsr,var(--_1u7yt41,revert-layer))}[style]:before{position:var(--_nej54n,revert-layer);z-index:var(--_1f713oa,revert-layer);content:var(--_16uwti7,revert-layer);inset:var(--_1vokwbf,revert-layer);background:var(--_rt68g4,revert-layer)}[style]:after{content:var(--_1swegf4,var(--_d9agn9,revert-layer))}}@layer tks2{[style]{font-size:var(--_axuivf,revert-layer);--_axuivf:var(--xxl)var(--xxl_font-size)}.tk-utbdlz,[style]{--_1gqxh9p:var(--hover)var(--hover_background-color);--_aoiy32:var(--\{\&\;focus\;hover\})var(--\{\&\;focus\;hover\}_background-color)}.tk-utbdlz,[style],[style] .card,[style]>p,[style] p{background-color:var(--_aoiy32,var(--_134znwc,var(--_nf2ooy,var(--_163r6xx,var(--_1gqxh9p,revert-layer)))))}[style]>p{--_163r6xx:var(--child-p)var(--child-p_background-color)}[style*=selection_]::selection{background-color:var(--_9t0pqg,revert-layer)}[style*=selection_]{--_9t0pqg:var(--selection)var(--selection_background-color)}[style] p{--_nf2ooy:var(--prose-p)var(--prose-p_background-color)}[style] .card{--_134znwc:var(--prose-card)var(--prose-card_background-color)}}@layer tksl1{[style]{inline-size:var(--_1imu60m,revert-layer);--_1imu60m:var(--md)var(--_1q1n7d5,var(--md_inline-size));--_1q1n7d5:var(--md_inline-size__calc)calc(var(--md_inline-size)*var(--_grid));block-size:var(--_qqcymk,revert-layer);--_qqcymk:var(--md)var(--_he48ex,var(--md_block-size));--_he48ex:var(--md_block-size__calc)calc(var(--md_block-size)*var(--_grid))}}@layer tksl2{[style]>p{padding-inline:var(--_1wrhsdd,revert-layer);--_1wrhsdd:var(--child-p)var(--_152jnev,var(--child-p_padding-inline));--_152jnev:var(--child-p_padding-inline__calc)calc(var(--child-p_padding-inline)*var(--_grid))}}@layer tkc{.tk-utbdlz{--background-color:var(--color_violet9);--color:var(--color_white);--border-block-end:var(--line_px);--border-block-color:var(--color_violet11);--border-inline-color:var(--color_violet11);--border-radius:var(--radii_lg);--inline-size:45;--inline-size__calc: ;--block-size:15;--block-size__calc: ;--transition:var(--morph_all);--hover_background-color:var(--color_violet10);--hover_animation:var(--anim_wiggle);--\{\&\;focus\;hover\}_background-color:var(---,red)}.tk-erz9s7{--border:var(--line_8);--border-block-color:var(--color_red10);--border-inline-color:var(--color_red10)}.tk-rychtn{--object-fit:cover;--border-block-color:var(--color_iris10);--border-inline-color:var(--color_iris10)}}
+@layer global {
+  :root {
+    --font-family: ui-sans-serif, system-ui, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
+    --font-stretch: normal;
+    --font-style: normal;
+    --font-variant: normal;
+    --font-weight: normal;
+  }
+
+  *, :before, :after {
+    box-sizing: border-box;
+    border: 0;
+    margin: 0;
+    padding: 0;
+  }
+
+  html, :host {
+    -webkit-text-size-adjust: 100%;
+    tab-size: 4;
+    line-height: 1.5;
+    font-family: var(--font-family);
+    font-feature-settings: normal;
+    font-variation-settings: normal;
+    -webkit-tap-highlight-color: transparent;
+  }
+
+  body {
+    line-height: inherit;
+  }
+
+  hr {
+    height: 0;
+    color: inherit;
+    border-top-width: 1px;
+  }
+
+  abbr:where([title]) {
+    text-decoration: underline dotted;
+  }
+
+  h1, h2, h3, h4, h5, h6 {
+    font-size: inherit;
+    font-weight: inherit;
+  }
+
+  a {
+    color: inherit;
+    text-decoration: inherit;
+  }
+
+  b, strong {
+    font-weight: bolder;
+  }
+
+  code, kbd, samp, pre {
+    --font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+    font-family: var(--font-family);
+    font-feature-settings: normal;
+    font-variation-settings: normal;
+    font-size: 1em;
+  }
+
+  small {
+    font-size: 80%;
+  }
+
+  sub, sup {
+    vertical-align: baseline;
+    font-size: 75%;
+    line-height: 0;
+    position: relative;
+  }
+
+  sub {
+    bottom: -.25em;
+  }
+
+  sup {
+    top: -.5em;
+  }
+
+  table {
+    text-indent: 0;
+    border-color: inherit;
+    border-collapse: collapse;
+  }
+
+  button, input, optgroup, select, textarea {
+    font: inherit;
+    font-feature-settings: inherit;
+    font-variation-settings: inherit;
+    letter-spacing: inherit;
+    color: inherit;
+    background: none;
+  }
+
+  ::file-selector-button {
+    font: inherit;
+    font-feature-settings: inherit;
+    font-variation-settings: inherit;
+    letter-spacing: inherit;
+    color: inherit;
+    background: none;
+  }
+
+  input:where(:not([type="button"], [type="reset"], [type="submit"])), select, textarea {
+    border: 1px solid;
+  }
+
+  button, input:where([type="button"]), input:where([type="reset"]), input:where([type="submit"]) {
+    appearance: button;
+  }
+
+  ::file-selector-button {
+    appearance: button;
+  }
+
+  :-moz-focusring {
+    outline: auto;
+  }
+
+  :-moz-ui-invalid {
+    box-shadow: none;
+  }
+
+  progress {
+    vertical-align: baseline;
+  }
+
+  ::-webkit-inner-spin-button {
+    height: auto;
+  }
+
+  ::-webkit-outer-spin-button {
+    height: auto;
+  }
+
+  ::-webkit-search-decoration {
+    -webkit-appearance: none;
+  }
+
+  summary {
+    display: list-item;
+  }
+
+  ol, ul, menu {
+    list-style: none;
+  }
+
+  textarea {
+    resize: vertical;
+  }
+
+  ::placeholder {
+    opacity: 1;
+    color: color-mix(in srgb, currentColor 50%, transparent);
+  }
+
+  img, svg, video, canvas, audio, iframe, embed, object {
+    vertical-align: middle;
+    display: block;
+  }
+
+  [hidden]:not([hidden="until-found"]) {
+    display: none;
+  }
+}
+
+@layer tkb {
+  @keyframes pulse {
+    0%, 100% {
+      opacity: 1;
+    }
+
+    50% {
+      opacity: .5;
+    }
+  }
+
+  @keyframes wiggle {
+    0%, 100% {
+      transform: rotate(-3deg);
+    }
+
+    50% {
+      transform: rotate(3deg);
+    }
+  }
+
+  :root {
+    --_grid: .25rem;
+    --anim_pulse: pulse 2s cubic-bezier(.4, 0, .6, 1) infinite;
+    --anim_wiggle: wiggle 1s ease-in-out infinite;
+    --font_mono: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+    --font_sans: ui-sans-serif, system-ui, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
+    --leading_7: 1.75rem;
+    --leading_loose: 2;
+    --line-size_4: .25rem;
+    --line_0: 0 solid;
+    --line_8: .5rem solid;
+    --line_px: .0625rem solid;
+    --morph_all: all cubic-bezier(.4, 0, .2, 1) .15s;
+    --radii_3xl: 1.5rem;
+    --radii_full: 9999px;
+    --radii_lg: .5rem;
+    --radii_none: 0;
+    --radii_sm: .125rem;
+    --radii_xl: .75rem;
+    --size_auto: auto;
+    --size_half: 50%;
+    --size_screen-h: 100vh;
+    --text-size_4xl: 2.25rem;
+    --text-size_lg: 1.125rem;
+    --text-size_xl: 1.25rem;
+    --weight_medium: 500;
+  }
+
+  :root, :root [style], :root .tk-utbdlz, :root [style*="selection_"], :root [style] > p, :root [style] p, :root [style] .card, :root .tk-erz9s7, :root .tk-rychtn {
+    --gradient_to-b: linear-gradient(to bottom in var(--_color-space, srgb), var(--_gradient-from) var(--_gradient-from-stop, ), var(---via, var(--_gradient-to) var(--_gradient-to-stop, )));
+    ---via: var(--_gradient-via) var(--_gradient-via-stop, ), var(--_gradient-to);
+    --text_base: var(--font-stretch) var(--font-style) var(--font-variant) var(--font-weight) 1rem / 1.5rem var(--font-family);
+    --text_xl: var(--font-stretch) var(--font-style) var(--font-variant) var(--font-weight) 1.25rem / 1.75rem var(--font-family);
+  }
+
+  :root, [data-theme="light"] {
+    --color_amber12: #4f3422;
+    --color_amber8: #e2a336;
+    --color_amber9: #ffc442;
+    --color_gray10: #838383;
+    --color_gray11: #646464;
+    --color_gray7: #cecece;
+    --color_gray8: #bbb;
+    --color_green9: #30a46c;
+    --color_indigo10: #3358d4;
+    --color_indigo5: #d2deff;
+    --color_indigo6: #c1d0ff;
+    --color_indigo8: #8da4ef;
+    --color_iris10: #5151cd;
+    --color_red10: #dd3e42;
+    --color_red8: #eb8e90;
+    --color_red9: #e5484d;
+    --color_violet10: #654dc4;
+    --color_violet11: #6550b9;
+    --color_violet9: #6e56cf;
+    --color_white: #fff;
+    --pet_favourite: "🐶";
+  }
+
+  @supports (color: color(display-p3 0 0 0)) {
+    :root, [data-theme="light"] {
+      --color_amber12: color(display-p3 .294 .208 .145);
+      --color_amber8: color(display-p3 .85 .65 .3);
+      --color_amber9: color(display-p3 1 .77 .26);
+      --color_gray10: color(display-p3 .512 .512 .512);
+      --color_gray11: color(display-p3 .392 .392 .392);
+      --color_gray7: color(display-p3 .807 .807 .807);
+      --color_gray8: color(display-p3 .732 .732 .732);
+      --color_green9: color(display-p3 .332 .634 .442);
+      --color_indigo10: color(display-p3 .234 .343 .801);
+      --color_indigo5: color(display-p3 .831 .87 1);
+      --color_indigo6: color(display-p3 .767 .814 .995);
+      --color_indigo8: color(display-p3 .569 .639 .916);
+      --color_iris10: color(display-p3 .318 .318 .774);
+      --color_red10: color(display-p3 .798 .294 .285);
+      --color_red8: color(display-p3 .872 .575 .572);
+      --color_red9: color(display-p3 .83 .329 .324);
+      --color_violet10: color(display-p3 .381 .306 .741);
+      --color_violet11: color(display-p3 .383 .317 .702);
+      --color_violet9: color(display-p3 .417 .341 .784);
+      --color_white: color(display-p3 1 1 1);
+    }
+  }
+
+  [data-theme="dark"] {
+    --color_amber12: #ffe7b3;
+    --color_amber8: #8f6424;
+    --color_amber9: #ffc442;
+    --color_gray10: #7b7b7b;
+    --color_gray11: #b4b4b4;
+    --color_gray7: #484848;
+    --color_gray8: #606060;
+    --color_green9: #30a46c;
+    --color_indigo10: #5472e4;
+    --color_indigo5: #253974;
+    --color_indigo6: #304384;
+    --color_indigo8: #435db2;
+    --color_iris10: #6e6ade;
+    --color_red10: #ec5e5e;
+    --color_red8: #b54548;
+    --color_red9: #e5484d;
+    --color_violet10: #7d66d9;
+    --color_violet11: #bba6ff;
+    --color_violet9: #6e56cf;
+    --color_white: #fff;
+    --pet_favourite: "🐱";
+  }
+
+  @supports (color: color(display-p3 0 0 0)) {
+    [data-theme="dark"] {
+      --color_amber12: color(display-p3 .984 .909 .726);
+      --color_amber8: color(display-p3 .535 .399 .189);
+      --color_amber9: color(display-p3 1 .77 .26);
+      --color_gray10: color(display-p3 .484 .484 .484);
+      --color_gray11: color(display-p3 .706 .706 .706);
+      --color_gray7: color(display-p3 .283 .283 .283);
+      --color_gray8: color(display-p3 .375 .375 .375);
+      --color_green9: color(display-p3 .332 .634 .442);
+      --color_indigo10: color(display-p3 .354 .445 .866);
+      --color_indigo5: color(display-p3 .163 .22 .439);
+      --color_indigo6: color(display-p3 .203 .262 .5);
+      --color_indigo8: color(display-p3 .285 .362 .674);
+      --color_iris10: color(display-p3 .428 .416 .843);
+      --color_red10: color(display-p3 .861 .403 .387);
+      --color_red8: color(display-p3 .659 .298 .297);
+      --color_red9: color(display-p3 .83 .329 .324);
+      --color_violet10: color(display-p3 .477 .402 .823);
+      --color_violet11: color(display-p3 .72 .65 1);
+      --color_violet9: color(display-p3 .417 .341 .784);
+      --color_white: color(display-p3 1 1 1);
+    }
+  }
+
+  * {
+    --background-color: initial;
+    --\{\&\;focus\;hover\}_background-color: initial;
+    --\{\&\;focus\;hover\}: initial;
+    --_aoiy32: initial;
+    --hover_background-color: initial;
+    --hover: initial;
+    --_1gqxh9p: initial;
+    --selection_background-color: initial;
+    --selection: initial;
+    --_9t0pqg: initial;
+    --child-p: initial;
+    --_163r6xx: initial;
+    --prose-p: initial;
+    --_nf2ooy: initial;
+    --prose-card: initial;
+    --_134znwc: initial;
+    --border-block-end: initial;
+    --border-block-color: initial;
+    --border-inline-color: initial;
+    --border-radius: initial;
+    --md_border-radius: initial;
+    --md: initial;
+    --_1u7yt41: initial;
+    --_d4svsr: initial;
+    --inline-size: initial;
+    --inline-size__calc: initial;
+    --md_inline-size: initial;
+    --md_inline-size__calc: initial;
+    --_1imu60m: initial;
+    --block-size: initial;
+    --block-size__calc: initial;
+    --md_block-size: initial;
+    --md_block-size__calc: initial;
+    --_qqcymk: initial;
+    --transition: initial;
+    --hover_animation: initial;
+    --_xgpg9b: initial;
+    --_ez0gpl: initial;
+    --_xksefa: initial;
+    --min-height: initial;
+    --min-height__calc: initial;
+    --background-size: initial;
+    --background-image: initial;
+    --background-position-x: initial;
+    --background-position-x__calc: initial;
+    --background-position-y: initial;
+    --background-position-y__calc: initial;
+    --display: initial;
+    --md_display: initial;
+    --_1loixh8: initial;
+    --flex-direction: initial;
+    --align-items: initial;
+    --justify-content: initial;
+    --padding-inline: initial;
+    --padding-inline__calc: initial;
+    --_1wrhsdd: initial;
+    --position: initial;
+    --before_position: initial;
+    --before: initial;
+    --_nej54n: initial;
+    --z-index: initial;
+    --before_z-index: initial;
+    --_1f713oa: initial;
+    --padding: initial;
+    --padding__calc: initial;
+    --md_padding: initial;
+    --md_padding__calc: initial;
+    --_1432d1p: initial;
+    --margin: initial;
+    --margin__calc: initial;
+    --after_content: initial;
+    --after: initial;
+    --_d9agn9: initial;
+    --before_content: initial;
+    --_16uwti7: initial;
+    --md_after_content: initial;
+    --md_after: initial;
+    --_1swegf4: initial;
+    --before_inset: initial;
+    --before_inset__calc: initial;
+    --_1vokwbf: initial;
+    --background: initial;
+    --before_background: initial;
+    --_rt68g4: initial;
+    --before_gradient-from: initial;
+    --_blthfh: initial;
+    --before_gradient-to: initial;
+    --_jkmljo: initial;
+    --_18hd4n5: initial;
+    --overflow: initial;
+    --padding-block: initial;
+    --padding-block__calc: initial;
+    --justify-items: initial;
+    --padding-block-start: initial;
+    --padding-block-start__calc: initial;
+    --xxl: initial;
+    --_axuivf: initial;
+    --margin-block-end: initial;
+    --margin-block-end__calc: initial;
+    --margin-inline: initial;
+    --margin-inline__calc: initial;
+    --margin-inline-start: initial;
+    --margin-inline-start__calc: initial;
+    --border: initial;
+    --margin-block: initial;
+    --margin-block__calc: initial;
+    --border-start-start-radius: initial;
+    --border-start-end-radius: initial;
+    --margin-block-start: initial;
+    --margin-block-start__calc: initial;
+    --border-block-width: initial;
+    --border-inline-width: initial;
+    --object-fit: initial;
+  }
+
+  [style]:focus:hover, .tk-utbdlz:focus:hover {
+    --\{\&\;focus\;hover\}: ;
+  }
+
+  @media (hover: hover) and (pointer: fine) {
+    [style]:not(:disabled):hover, .tk-utbdlz:not(:disabled):hover {
+      --hover: ;
+    }
+  }
+
+  [style*="selection_"] {
+    --selection: ;
+  }
+
+  [style] > p {
+    --child-p: ;
+  }
+
+  [style] p {
+    --prose-p: ;
+  }
+
+  [style] .card {
+    --prose-card: ;
+  }
+
+  @media (width >= 48rem) {
+    [style] {
+      --md: ;
+      --md_after: ;
+    }
+  }
+
+  [style] {
+    --before: ;
+    --after: ;
+  }
+
+  @media (width >= 96rem) {
+    [style] {
+      --xxl: ;
+    }
+  }
+}
+
+@layer tk1 {
+  [style] {
+    font: var(--font, revert-layer);
+    min-height: var(--_lmglzt, var(--min-height, revert-layer));
+    --_lmglzt: var(--min-height__calc) calc(var(--min-height) * var(--_grid));
+    display: var(--display, revert-layer);
+    position: var(--position, revert-layer);
+    z-index: var(--z-index, revert-layer);
+    padding: var(--_443yf1, var(--padding, revert-layer));
+    --_443yf1: var(--padding__calc) calc(var(--padding) * var(--_grid));
+    margin: var(--_1ty9hq, var(--margin, revert-layer));
+    --_1ty9hq: var(--margin__calc) calc(var(--margin) * var(--_grid));
+    background: var(--background, revert-layer);
+    text-align: var(--text-align, revert-layer);
+    overflow: var(--overflow, revert-layer);
+  }
+
+  .tk-utbdlz, [style] {
+    border-radius: var(--border-radius, revert-layer);
+    transition: var(--transition, revert-layer);
+    color: var(--color, revert-layer);
+  }
+
+  .tk-erz9s7, [style] {
+    border: var(--border, revert-layer);
+  }
+
+  .tk-rychtn, [style] {
+    object-fit: var(--object-fit, revert-layer);
+  }
+}
+
+@layer tk2 {
+  [style] {
+    font-family: var(--font-family, revert-layer);
+    font-stretch: var(--font-stretch, revert-layer);
+    font-style: var(--font-style, revert-layer);
+    font-variant: var(--font-variant, revert-layer);
+    font-weight: var(--font-weight, revert-layer);
+    background-size: var(--background-size, revert-layer);
+    background-image: var(--background-image, revert-layer);
+    flex-direction: var(--flex-direction, revert-layer);
+    align-items: var(--align-items, revert-layer);
+    justify-content: var(--justify-content, revert-layer);
+    justify-items: var(--justify-items, revert-layer);
+    line-height: var(--line-height, revert-layer);
+    font-size: var(--font-size, revert-layer);
+    border-start-start-radius: var(--border-start-start-radius, revert-layer);
+    border-start-end-radius: var(--border-start-end-radius, revert-layer);
+  }
+
+  .tk-utbdlz, [style] {
+    background-color: var(--background-color, revert-layer);
+  }
+}
+
+@layer tk3 {
+  [style] {
+    background-position-x: var(--_j8nb15, var(--background-position-x, revert-layer));
+    --_j8nb15: var(--background-position-x__calc) calc(var(--background-position-x) * var(--_grid));
+    background-position-y: var(--_15wunjl, var(--background-position-y, revert-layer));
+    --_15wunjl: var(--background-position-y__calc) calc(var(--background-position-y) * var(--_grid));
+  }
+}
+
+@layer tkl1 {
+  .tk-utbdlz, [style] {
+    inline-size: var(--_a9n10r, var(--inline-size, revert-layer));
+    --_a9n10r: var(--inline-size__calc) calc(var(--inline-size) * var(--_grid));
+    block-size: var(--_19kaxgm, var(--block-size, revert-layer));
+    --_19kaxgm: var(--block-size__calc) calc(var(--block-size) * var(--_grid));
+  }
+}
+
+@layer tkl2 {
+  [style] {
+    padding-inline: var(--_twrjq1, var(--padding-inline, revert-layer));
+    --_twrjq1: var(--padding-inline__calc) calc(var(--padding-inline) * var(--_grid));
+    padding-block: var(--_11by1jg, var(--padding-block, revert-layer));
+    --_11by1jg: var(--padding-block__calc) calc(var(--padding-block) * var(--_grid));
+    margin-inline: var(--_2243e5, var(--margin-inline, revert-layer));
+    --_2243e5: var(--margin-inline__calc) calc(var(--margin-inline) * var(--_grid));
+    margin-block: var(--_1rd6zpk, var(--margin-block, revert-layer));
+    --_1rd6zpk: var(--margin-block__calc) calc(var(--margin-block) * var(--_grid));
+  }
+}
+
+@layer tkl3 {
+  [style] {
+    --_193cv1f: var(--padding-block-start__calc) calc(var(--padding-block-start) * var(--_grid));
+    --_rq4yuw: var(--margin-block-end__calc) calc(var(--margin-block-end) * var(--_grid));
+    --_sn3kh4: var(--margin-inline-start__calc) calc(var(--margin-inline-start) * var(--_grid));
+    --_1x10y43: var(--margin-block-start__calc) calc(var(--margin-block-start) * var(--_grid));
+    margin-block-start: var(--_1x10y43, var(--margin-block-start, revert-layer));
+    margin-block-end: var(--_rq4yuw, var(--margin-block-end, revert-layer));
+    margin-inline-start: var(--_sn3kh4, var(--margin-inline-start, revert-layer));
+    padding-block-start: var(--_193cv1f, var(--padding-block-start, revert-layer));
+  }
+
+  .tk-utbdlz, [style] {
+    border-block-end: var(--border-block-end, revert-layer);
+  }
+}
+
+@layer tkl5 {
+  [style] {
+    border-block-width: var(--border-block-width, revert-layer);
+    border-inline-width: var(--border-inline-width, revert-layer);
+  }
+
+  .tk-erz9s7, .tk-rychtn, .tk-utbdlz, [style] {
+    border-block-color: var(--border-block-color, revert-layer);
+    border-inline-color: var(--border-inline-color, revert-layer);
+  }
+}
+
+@layer tks1 {
+  [style] {
+    --_1u7yt41: var(--md) var(--md_border-radius);
+    color: var(--_ez0gpl, revert-layer);
+    --_ez0gpl: var(--hover) var(--hover_color);
+    display: var(--_1loixh8, revert-layer);
+    --_1loixh8: var(--md) var(--md_display);
+    --_nej54n: var(--before) var(--before_position);
+    --_1f713oa: var(--before) var(--before_z-index);
+    padding: var(--_1432d1p, revert-layer);
+    --_1432d1p: var(--md) var(--_6cxmw0, var(--md_padding));
+    --_6cxmw0: var(--md_padding__calc) calc(var(--md_padding) * var(--_grid));
+    --_d9agn9: var(--after) var(--after_content);
+    --_16uwti7: var(--before) var(--before_content);
+    --_1swegf4: var(--md_after) var(--md_after_content);
+    --_1vokwbf: var(--before) var(--_a6shpi, var(--before_inset));
+    --_a6shpi: var(--before_inset__calc) calc(var(--before_inset) * var(--_grid));
+    --_rt68g4: var(--before) var(--before_background);
+    --_gradient-from: var(--_blthfh, var(--gradient-from));
+    --_blthfh: var(--before) var(--before_gradient-from);
+    --_gradient-to: var(--_jkmljo, var(--gradient-to));
+    --_jkmljo: var(--before) var(--before_gradient-to);
+    text-align: var(--_18hd4n5, revert-layer);
+    --_18hd4n5: var(--md) var(--md_text-align);
+  }
+
+  .tk-utbdlz, [style] {
+    animation: var(--_xgpg9b, revert-layer);
+    --_xgpg9b: var(--hover) var(--hover_animation);
+  }
+
+  [style*="selection_"]::selection {
+    color: var(--_xksefa, revert-layer);
+  }
+
+  [style*="selection_"] {
+    --_xksefa: var(--selection) var(--selection_color);
+  }
+
+  [style] > p {
+    --_d4svsr: var(--child-p) var(--child-p_border-radius);
+  }
+
+  [style], [style] > p {
+    border-radius: var(--_d4svsr, var(--_1u7yt41, revert-layer));
+  }
+
+  [style]:before {
+    position: var(--_nej54n, revert-layer);
+    z-index: var(--_1f713oa, revert-layer);
+    content: var(--_16uwti7, revert-layer);
+    inset: var(--_1vokwbf, revert-layer);
+    background: var(--_rt68g4, revert-layer);
+  }
+
+  [style]:after {
+    content: var(--_1swegf4, var(--_d9agn9, revert-layer));
+  }
+}
+
+@layer tks2 {
+  [style] {
+    font-size: var(--_axuivf, revert-layer);
+    --_axuivf: var(--xxl) var(--xxl_font-size);
+  }
+
+  .tk-utbdlz, [style] {
+    --_aoiy32: var(--\{\&\;focus\;hover\}) var(--\{\&\;focus\;hover\}_background-color);
+    --_1gqxh9p: var(--hover) var(--hover_background-color);
+  }
+
+  .tk-utbdlz, [style], [style] .card, [style] > p, [style] p {
+    background-color: var(--_134znwc, var(--_nf2ooy, var(--_163r6xx, var(--_1gqxh9p, var(--_aoiy32, revert-layer)))));
+  }
+
+  [style*="selection_"]::selection {
+    background-color: var(--_9t0pqg, revert-layer);
+  }
+
+  [style*="selection_"] {
+    --_9t0pqg: var(--selection) var(--selection_background-color);
+  }
+
+  [style] > p {
+    --_163r6xx: var(--child-p) var(--child-p_background-color);
+  }
+
+  [style] p {
+    --_nf2ooy: var(--prose-p) var(--prose-p_background-color);
+  }
+
+  [style] .card {
+    --_134znwc: var(--prose-card) var(--prose-card_background-color);
+  }
+}
+
+@layer tksl1 {
+  [style] {
+    inline-size: var(--_1imu60m, revert-layer);
+    --_1imu60m: var(--md) var(--_1q1n7d5, var(--md_inline-size));
+    --_1q1n7d5: var(--md_inline-size__calc) calc(var(--md_inline-size) * var(--_grid));
+    block-size: var(--_qqcymk, revert-layer);
+    --_qqcymk: var(--md) var(--_he48ex, var(--md_block-size));
+    --_he48ex: var(--md_block-size__calc) calc(var(--md_block-size) * var(--_grid));
+  }
+}
+
+@layer tksl2 {
+  [style] > p {
+    padding-inline: var(--_1wrhsdd, revert-layer);
+    --_1wrhsdd: var(--child-p) var(--_152jnev, var(--child-p_padding-inline));
+    --_152jnev: var(--child-p_padding-inline__calc) calc(var(--child-p_padding-inline) * var(--_grid));
+  }
+}
+
+@layer tkc {
+  .tk-utbdlz {
+    --background-color: var(--color_violet9);
+    --color: var(--color_white);
+    --border-block-end: var(--line_px);
+    --border-block-color: var(--color_violet11);
+    --border-inline-color: var(--color_violet11);
+    --border-radius: var(--radii_lg);
+    --inline-size: 45;
+    --inline-size__calc: ;
+    --block-size: 15;
+    --block-size__calc: ;
+    --transition: var(--morph_all);
+    --hover_background-color: var(--color_violet10);
+    --hover_animation: var(--anim_wiggle);
+    --\{\&\;focus\;hover\}_background-color: var(---, red);
+  }
+
+  .tk-erz9s7 {
+    --border: var(--line_8);
+    --border-block-color: var(--color_red10);
+    --border-inline-color: var(--color_red10);
+  }
+
+  .tk-rychtn {
+    --object-fit: cover;
+    --border-block-color: var(--color_iris10);
+    --border-inline-color: var(--color_iris10);
+  }
+}


### PR DESCRIPTION
# Summary

Previously arbitrary selectors were ordered by discovery (not deterministic—oops). This makes sure named selectors from config always win, and then orders arbitrary ones by hash. To control arbitrary selector order, promote them to the config as named selectors.

## Change Type

<!-- Please indicate the type of change this is -->

- [ ] `documentation`
- [x] `patch`
- [ ] `minor`
- [ ] `major`

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.0.100--canary.516.27908880292.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @tokenami/example-design-system@0.0.100--canary.516.27908880292.0
  npm install @tokenami/example-nextjs@0.0.100--canary.516.27908880292.0
  npm install @tokenami/cli@0.0.100--canary.516.27908880292.0
  npm install @tokenami/config@0.0.100--canary.516.27908880292.0
  npm install @tokenami/css@0.0.100--canary.516.27908880292.0
  npm install @tokenami/ds@0.0.100--canary.516.27908880292.0
  npm install @tokenami/node@0.0.100--canary.516.27908880292.0
  npm install @tokenami/unplugin@0.0.100--canary.516.27908880292.0
  npm install tokenami@0.0.100--canary.516.27908880292.0
  # or 
  yarn add @tokenami/example-design-system@0.0.100--canary.516.27908880292.0
  yarn add @tokenami/example-nextjs@0.0.100--canary.516.27908880292.0
  yarn add @tokenami/cli@0.0.100--canary.516.27908880292.0
  yarn add @tokenami/config@0.0.100--canary.516.27908880292.0
  yarn add @tokenami/css@0.0.100--canary.516.27908880292.0
  yarn add @tokenami/ds@0.0.100--canary.516.27908880292.0
  yarn add @tokenami/node@0.0.100--canary.516.27908880292.0
  yarn add @tokenami/unplugin@0.0.100--canary.516.27908880292.0
  yarn add tokenami@0.0.100--canary.516.27908880292.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
